### PR TITLE
Automatically determine and setup dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,9 @@ Usage
         /** @see \PHPUnit_Framework_TestCase::setUp() */
         protected function setUp()
         {
-            $this->infrastructure = new ORMInfrastructure(
+            $this->infrastructure = ORMInfrastructure::createWithDependenciesFor(
                 array(
-                    'Entity\MyEntity',
-                    // recursively add all class names of associated classes
+                    'Entity\MyEntity'
                 )
             );
             $this->repository = $this->infrastructure->getRepository('Entity\MyEntity');

--- a/README.md
+++ b/README.md
@@ -56,9 +56,7 @@ Usage
         protected function setUp()
         {
             $this->infrastructure = ORMInfrastructure::createWithDependenciesFor(
-                array(
-                    'Entity\MyEntity'
-                )
+                'Entity\MyEntity'
             );
             $this->repository = $this->infrastructure->getRepository('Entity\MyEntity');
         }

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Testing the library itself
 
 After installing the dependencies managed via composer, just run
 
-    php vendor/phpunit/phpunit/phpunit.php
+    vendor/bin/phpunit
 
 from the library's root folder. This uses the shipped phpunit.xml.dist - feel free to create your own phpunit.xml if you
 need local changes.

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/ConfigurationFactory.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/ConfigurationFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * (c) webfactory GmbH <info@webfactory.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure;
+
+/**
+ * Creates ORM configurations for a set of entities.
+ *
+ * These configurations are meant for testing only.
+ */
+class ConfigurationFactory
+{
+    /**
+     * Creates the ORM configuration for the given set of entities.
+     *
+     * @param string[] $entityClasses
+     * @return \Doctrine\ORM\Configuration
+     */
+    public function createFor(array $entityClasses)
+    {
+
+    }
+}

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/ConfigurationFactory.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/ConfigurationFactory.php
@@ -43,8 +43,8 @@ class ConfigurationFactory
     /**
      * Returns a list of file paths for the provided class names.
      *
-     * @param array(string) $classNames
-     * @return array(string)
+     * @param string[] $classNames
+     * @return string[]
      */
     protected function getFilePathsForClassNames(array $classNames)
     {

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/ConfigurationFactory.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/ConfigurationFactory.php
@@ -9,6 +9,9 @@
 
 namespace Webfactory\Doctrine\ORMTestInfrastructure;
 
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\ORM\Tools\Setup;
+
 /**
  * Creates ORM configurations for a set of entities.
  *
@@ -24,6 +27,43 @@ class ConfigurationFactory
      */
     public function createFor(array $entityClasses)
     {
+        $config = Setup::createAnnotationMetadataConfiguration(
+            $this->getFilePathsForClassNames($entityClasses),
+            // Activate development mode.
+            true,
+            // Store proxies in the default temp directory.
+            null,
+            // Avoid Doctrine auto-detection of cache and use an isolated cache.
+            new ArrayCache(),
+            false
+        );
+        return $config;
+    }
 
+    /**
+     * Returns a list of file paths for the provided class names.
+     *
+     * @param array(string) $classNames
+     * @return array(string)
+     */
+    protected function getFilePathsForClassNames(array $classNames)
+    {
+        $paths = array();
+        foreach ($classNames as $className) {
+            $paths[] = $this->getFilePathForClassName($className);
+        }
+        return array_unique($paths);
+    }
+
+    /**
+     * Returns the path to the directory that contains the given class.
+     *
+     * @param string $className
+     * @return string
+     */
+    protected function getFilePathForClassName($className)
+    {
+        $info = new \ReflectionClass($className);
+        return dirname($info->getFileName());
     }
 }

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolver.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolver.php
@@ -9,6 +9,12 @@
 
 namespace Webfactory\Doctrine\ORMTestInfrastructure;
 
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Tools\Setup;
+
 /**
  * Takes a set of entity classes and resolves to a set that contains all entities
  * that are referenced by the provided entity classes (via associations).
@@ -18,13 +24,20 @@ namespace Webfactory\Doctrine\ORMTestInfrastructure;
 class EntityDependencyResolver implements \IteratorAggregate
 {
     /**
+     * Contains the names of the entity classes that were initially provided.
+     *
+     * @var string[]
+     */
+    protected $initialEntitySet = null;
+
+    /**
      * Creates a resolver for the given entity classes.
      *
      * @param string[] $entityClasses
      */
     public function __construct(array $entityClasses)
     {
-
+        $this->initialEntitySet = $this->normalizeClassNames($entityClasses);
     }
 
     /**
@@ -35,6 +48,115 @@ class EntityDependencyResolver implements \IteratorAggregate
      */
     public function getIterator()
     {
+        return new \ArrayIterator($this->resolve($this->initialEntitySet));
+    }
 
+    /**
+     * Resolves the dependencies for the given entities.
+     *
+     * @param string[] $entityClasses
+     * @return string[]
+     */
+    protected function resolve(array $entityClasses)
+    {
+        $entitiesToCheck = $entityClasses;
+        $config = $this->createConfigFor($entitiesToCheck);
+        while (count($associatedEntities = $this->getDirectlyAssociatedEntities($config, $entitiesToCheck)) > 0) {
+            $newAssociations = array_diff($associatedEntities, $entityClasses);
+            $entityClasses = array_merge($entityClasses, $newAssociations);
+            $config = $this->createConfigFor($entityClasses);
+            $entitiesToCheck = $newAssociations;
+        }
+        return $entityClasses;
+    }
+
+    /**
+     * Returns the class names of additional entities that are directly associated with
+     * one of the entities that is explicitly mentioned in the given configuration.
+     *
+     * @param Configuration $config
+     * @param string[] $entityClasses Classes whose associations are checked.
+     * @return string[] Associated entity classes.
+     */
+    protected function getDirectlyAssociatedEntities(Configuration $config, $entityClasses)
+    {
+        if (count($entityClasses) === 0) {
+            return array();
+        }
+        $associatedEntities = array();
+        $reflection = new RuntimeReflectionService();
+        foreach ($entityClasses as $entityClass) {
+            /* @var $entityClass string */
+            $metadata = new ClassMetadata($entityClass);
+            $metadata->initializeReflection($reflection);
+            $config->getMetadataDriverImpl()->loadMetadataForClass($entityClass, $metadata);
+            foreach ($metadata->getAssociationNames() as $name) {
+                /* @var $name string */
+                $associatedEntity = $metadata->getAssociationTargetClass($name);
+                $associatedEntities[] = $metadata->fullyQualifiedClassName($associatedEntity);
+            }
+        }
+        return array_unique($associatedEntities);
+    }
+
+    /**
+     * Creates a Doctrine configuration for the given entity classes.
+     *
+     * @param string[] $entityClasses
+     * @return \Doctrine\ORM\Configuration
+     */
+    protected function createConfigFor(array $entityClasses)
+    {
+        $config = Setup::createAnnotationMetadataConfiguration(
+            $this->getFilePathsForClassNames($entityClasses),
+            // Activate development mode.
+            true,
+            // Store proxies in the default temp directory.
+            null,
+            // Avoid Doctrine auto-detection of cache and use an isolated cache.
+            new ArrayCache(),
+            false
+        );
+        return $config;
+    }
+
+    /**
+     * Returns a list of file paths for the provided class names.
+     *
+     * @param array(string) $classNames
+     * @return array(string)
+     */
+    protected function getFilePathsForClassNames(array $classNames)
+    {
+        $paths = array();
+        foreach ($classNames as $className) {
+            $paths[] = $this->getFilePathForClassName($className);
+        }
+        return array_unique($paths);
+    }
+
+    /**
+     * Returns the path to the directory that contains the given class.
+     *
+     * @param string $className
+     * @return string
+     */
+    protected function getFilePathForClassName($className)
+    {
+        $info = new \ReflectionClass($className);
+        return dirname($info->getFileName());
+    }
+
+    /**
+     * Removes leading slashes from the given class names.
+     *
+     * @param string[] $entityClasses
+     * @return string[]
+     */
+    protected function normalizeClassNames(array $entityClasses)
+    {
+        return array_map(function ($class) {
+            return ltrim($class, '\\');
+        }, $entityClasses);
     }
 }

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolver.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolver.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * (c) webfactory GmbH <info@webfactory.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Webfactory\Doctrine\ORMTestInfrastructure;
 
 /**
@@ -8,7 +15,7 @@ namespace Webfactory\Doctrine\ORMTestInfrastructure;
  *
  * The resolved set also includes the original entity classes.
  */
-class EntityDependencyResolver
+class EntityDependencyResolver implements \IteratorAggregate
 {
     /**
      * Creates a resolver for the given entity classes.
@@ -16,6 +23,17 @@ class EntityDependencyResolver
      * @param string[] $entityClasses
      */
     public function __construct(array $entityClasses)
+    {
+
+    }
+
+    /**
+     * Allows iterating over the set of resolved entities.
+     *
+     * @return \Traversable
+     * @link http://php.net/manual/en/iteratoraggregate.getiterator.php
+     */
+    public function getIterator()
     {
 
     }

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolver.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolver.php
@@ -10,6 +10,7 @@
 namespace Webfactory\Doctrine\ORMTestInfrastructure;
 
 use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Persistence\Mapping\ReflectionService;
 use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -31,13 +32,21 @@ class EntityDependencyResolver implements \IteratorAggregate
     protected $initialEntitySet = null;
 
     /**
+     * Service that is used to inspect entity classes.
+     *
+     * @var ReflectionService
+     */
+    protected $reflectionService = null;
+
+    /**
      * Creates a resolver for the given entity classes.
      *
      * @param string[] $entityClasses
      */
     public function __construct(array $entityClasses)
     {
-        $this->initialEntitySet = $this->normalizeClassNames($entityClasses);
+        $this->initialEntitySet  = $this->normalizeClassNames($entityClasses);
+        $this->reflectionService = new RuntimeReflectionService();
     }
 
     /**
@@ -84,11 +93,10 @@ class EntityDependencyResolver implements \IteratorAggregate
             return array();
         }
         $associatedEntities = array();
-        $reflection = new RuntimeReflectionService();
         foreach ($entityClasses as $entityClass) {
             /* @var $entityClass string */
             $metadata = new ClassMetadata($entityClass);
-            $metadata->initializeReflection($reflection);
+            $metadata->initializeReflection($this->reflectionService);
             $config->getMetadataDriverImpl()->loadMetadataForClass($entityClass, $metadata);
             foreach ($metadata->getAssociationNames() as $name) {
                 /* @var $name string */

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolver.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolver.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure;
+
+/**
+ * Takes a set of entity classes and resolves to a set that contains all entities
+ * that are referenced by the provided entity classes (via associations).
+ *
+ * The resolved set also includes the original entity classes.
+ */
+class EntityDependencyResolver
+{
+    /**
+     * Creates a resolver for the given entity classes.
+     *
+     * @param string[] $entityClasses
+     */
+    public function __construct(array $entityClasses)
+    {
+
+    }
+}

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/Importer.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/Importer.php
@@ -123,7 +123,7 @@ class Importer
     /**
      * Imports a list of entities.
      *
-     * @param array(object) $entities
+     * @param object[] $entities
      */
     protected function importEntityList(array $entities)
     {

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
@@ -72,7 +72,7 @@ class ORMInfrastructure
     );
 
     /**
-     * List of entity classes that are manager by this helper.
+     * List of entity classes that are managed by this infrastructure.
      *
      * @var array(string)
      */

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
@@ -42,11 +42,11 @@ use Doctrine\ORM\Tools\SchemaTool;
  * ### Advanced Setup ###
  *
  * Use the ``createWithDependenciesFor()`` factory method to create an infrastructure for
- * the given entities, including all entities that are associated by these:
+ * the given entity, including all entities that are associated with it:
  *
- *     $infrastructure = ORMInfrastructure::createWithDependenciesFor(array(
+ *     $infrastructure = ORMInfrastructure::createWithDependenciesFor(
  *        'My\Entity\ClassName'
- *     ));
+ *     );
  *
  * This is convenient as it avoids touching tests when associations are added, but it
  * might also hide the existence of entity dependencies that you are not really aware

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
@@ -111,7 +111,6 @@ class ORMInfrastructure
      */
     protected $annotationLoader = null;
 
-
     /**
      * Creates an infrastructure for the given entity or entities, including all
      * referenced entities.

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
@@ -30,7 +30,7 @@ use Doctrine\ORM\Tools\Setup;
  *
  * Create the infrastructure for a set of entities:
  *
- *     $infrastructure = new ORMInfrastructure(array(
+ *     $infrastructure = ORMInfrastructure::createOnlyFor(array(
  *        'My\Entity\ClassName'
  *     ));
  *
@@ -40,6 +40,19 @@ use Doctrine\ORM\Tools\Setup;
  *
  * The entity manager can be used as usual. It operates on an in-memory database that contains
  * the schema for all entities that have been mentioned in the infrastructure constructor.
+ *
+ * ### Advanced Setup ###
+ *
+ * Use the ``createWithDependenciesFor()`` factory method to create an infrastructure for
+ * the given entities, including all entities that are associated by these:
+ *
+ *     $infrastructure = ORMInfrastructure::createWithDependenciesFor(array(
+ *        'My\Entity\ClassName'
+ *     ));
+ *
+ * This is convenient as it avoids touching tests when associations are added, but it
+ * might also hide the existence of entity dependencies that you are not really aware
+ * of.
  *
  * ## Import Test Data ##
  *
@@ -153,7 +166,7 @@ class ORMInfrastructure
         if ($entityClasses instanceof \Traversable) {
             $entityClasses = iterator_to_array($entityClasses);
         }
-        $this->entityClasses = $entityClasses;
+        $this->entityClasses    = $entityClasses;
         $this->annotationLoader = $this->createAnnotationLoader();
         $this->queryLogger      = new DebugStack();
         $this->addAnnotationLoaderToRegistry($this->annotationLoader);

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
@@ -109,6 +109,33 @@ class ORMInfrastructure
      */
     protected $annotationLoader = null;
 
+
+    /**
+     * Creates an infrastructure for the given entity or entities, including all
+     * referenced entities.
+     *
+     * @param string[]|string $entityClassOrClasses
+     * @return ORMInfrastructure
+     */
+    public static function createWithDependenciesFor($entityClassOrClasses)
+    {
+
+    }
+
+    /**
+     * Creates an infrastructure for the given entity or entities.
+     *
+     * The infrastructure that is required for entities that are associated with the given
+     * entities is *not* created automatically.
+     *
+     * @param string[]|string $entityClassOrClasses
+     * @return ORMInfrastructure
+     */
+    public static function createOnlyFor($entityClassOrClasses)
+    {
+
+    }
+
     /**
      * Creates an entity helper that provides a database infrastructure
      * for the provided entities.

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
@@ -156,6 +156,7 @@ class ORMInfrastructure
      *
      * @param array(string) $entityClasses
      * @param boolean $automaticallySetupDependencies Determines if associated entities are handled automatically.
+     * @deprecated Use one of the create*For() factory methods.
      */
     public function __construct(array $entityClasses, $automaticallySetupDependencies = false)
     {

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
@@ -162,10 +162,9 @@ class ORMInfrastructure
      * Foreach entity the fully qualified class name must be provided.
      *
      * @param string|\Traversable $entityClasses
-     * @param boolean $automaticallySetupDependencies Determines if associated entities are handled automatically.
      * @deprecated Use one of the create*For() factory methods.
      */
-    public function __construct($entityClasses, $automaticallySetupDependencies = false)
+    public function __construct($entityClasses)
     {
         if ($entityClasses instanceof \Traversable) {
             $entityClasses = iterator_to_array($entityClasses);
@@ -267,7 +266,7 @@ class ORMInfrastructure
      * Returns the metadata for each managed entity.
      *
      * @param ClassMetadataFactory $metadataFactory
-     * @return array(\Doctrine\Common\Persistence\Mapping\ClassMetadata)
+     * @return \Doctrine\Common\Persistence\Mapping\ClassMetadata[]
      */
     protected function getMetadataForSupportedEntities(ClassMetadataFactory $metadataFactory)
     {

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
@@ -161,7 +161,7 @@ class ORMInfrastructure
      *
      * Foreach entity the fully qualified class name must be provided.
      *
-     * @param string|\Traversable $entityClasses
+     * @param string[]|\Traversable $entityClasses
      * @deprecated Use one of the create*For() factory methods.
      */
     public function __construct($entityClasses)

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
@@ -119,7 +119,7 @@ class ORMInfrastructure
      */
     public static function createWithDependenciesFor($entityClassOrClasses)
     {
-
+        return new static(static::normalizeEntityList($entityClassOrClasses), true);
     }
 
     /**
@@ -133,7 +133,19 @@ class ORMInfrastructure
      */
     public static function createOnlyFor($entityClassOrClasses)
     {
+        return new static(static::normalizeEntityList($entityClassOrClasses), false);
+    }
 
+    /**
+     * Accepts a single entity class or a list of entity classes and always returns a
+     * list of entity classes.
+     *
+     * @param string[]|string $entityClassOrClasses
+     * @return string[]
+     */
+    protected static function normalizeEntityList($entityClassOrClasses)
+    {
+        return (is_string($entityClassOrClasses)) ? array($entityClassOrClasses) : $entityClassOrClasses;
     }
 
     /**

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/ConfigurationFactoryTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/ConfigurationFactoryTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * (c) webfactory GmbH <info@webfactory.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure;
+
+/**
+ * Tests the ORM configuration factory.
+ */
+class ConfigurationFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * System under test.
+     *
+     * @var ConfigurationFactory
+     */
+    protected $factory = null;
+
+    /**
+     * Initializes the test environment.
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->factory = new ConfigurationFactory();
+    }
+
+    /**
+     * Cleans up the test environment.
+     */
+    protected function tearDown()
+    {
+        $this->factory = null;
+        parent::tearDown();
+    }
+    /**
+     * Ensures that createFor() returns an ORM configuration object.
+     */
+    public function testCreateForReturnsConfiguration()
+    {
+        $configuration = $this->factory->createFor(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity'
+        ));
+
+        $this->assertInstanceOf('\Doctrine\ORM\Configuration', $configuration);
+    }
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
@@ -19,7 +19,11 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testResolverIsTraversable()
     {
+        $resolver = new EntityDependencyResolver(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity'
+        ));
 
+        $this->assertInstanceOf('\Traversable', $resolver);
     }
 
     /**
@@ -27,7 +31,14 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetContainsProvidedEntityClasses()
     {
+        $resolver = new EntityDependencyResolver(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity'
+        ));
 
+        $this->assertContains(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity',
+            $this->getResolvedSet($resolver)
+        );
     }
 
     /**
@@ -36,7 +47,14 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetContainsEntityClassesThatAreDirectlyConnectedToInitialSet()
     {
+        $resolver = new EntityDependencyResolver(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntityWithDependency'
+        ));
 
+        $this->assertContains(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity',
+            $this->getResolvedSet($resolver)
+        );
     }
 
     /**
@@ -49,7 +67,14 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetContainsIndirectlyConnectedEntityClasses()
     {
+        $resolver = new EntityDependencyResolver(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ChainReferenceEntity'
+        ));
 
+        $this->assertContains(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity',
+            $this->getResolvedSet($resolver)
+        );
     }
 
     /**
@@ -57,6 +82,44 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testResolverCanHandleDependencyCycles()
     {
+        $resolver = new EntityDependencyResolver(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferenceCycleEntity'
+        ));
 
+        $this->assertContains(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferenceCycleEntity',
+            $this->getResolvedSet($resolver)
+        );
+    }
+
+    /**
+     * Ensures that the resolved entity list contains each entity class only once.
+     */
+    public function testSetContainsEntitiesOnlyOnce()
+    {
+        $resolver = new EntityDependencyResolver(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferenceCycleEntity'
+        ));
+
+        $resolvedSet = $this->getResolvedSet($resolver);
+
+        $normalized = array_unique($resolvedSet);
+        sort($resolvedSet);
+        sort($normalized);
+        $this->assertEquals($normalized, $resolvedSet);
+    }
+
+    /**
+     * Returns the resolved set of entity classes as array.
+     *
+     * @param EntityDependencyResolver $resolver
+     * @return string[]
+     */
+    protected function getResolvedSet(EntityDependencyResolver $resolver)
+    {
+        $this->assertInstanceOf('\Traversable', $resolver);
+        $entities = iterator_to_array($resolver);
+        $this->assertContainsOnly('string', $entities);
+        return $entities;
     }
 }

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
@@ -35,9 +35,9 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
             '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity'
         ));
 
-        $this->assertContains(
+        $this->assertContainsEntity(
             '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity',
-            $this->getResolvedSet($resolver)
+            $resolver
         );
     }
 
@@ -51,9 +51,9 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
             '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntityWithDependency'
         ));
 
-        $this->assertContains(
+        $this->assertContainsEntity(
             '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity',
-            $this->getResolvedSet($resolver)
+            $resolver
         );
     }
 
@@ -71,9 +71,9 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
             '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ChainReferenceEntity'
         ));
 
-        $this->assertContains(
+        $this->assertContainsEntity(
             '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity',
-            $this->getResolvedSet($resolver)
+            $resolver
         );
     }
 
@@ -86,9 +86,9 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
             '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferenceCycleEntity'
         ));
 
-        $this->assertContains(
+        $this->assertContainsEntity(
             '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferenceCycleEntity',
-            $this->getResolvedSet($resolver)
+            $resolver
         );
     }
 
@@ -121,5 +121,20 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
         $entities = iterator_to_array($resolver);
         $this->assertContainsOnly('string', $entities);
         return $entities;
+    }
+
+    /**
+     * Asserts that the resolved entity list contains the given entity.
+     *
+     * @param string $entity Name of the entity class.
+     * @param EntityDependencyResolver|mixed $resolver
+     */
+    protected function assertContainsEntity($entity, $resolver)
+    {
+        $normalizedEntity = ltrim($entity, '\\');
+        $this->assertContains(
+            $normalizedEntity,
+            $this->getResolvedSet($resolver)
+        );
     }
 }

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
@@ -14,26 +14,47 @@ namespace Webfactory\Doctrine\ORMTestInfrastructure;
  */
 class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * Ensures that the resolver is traversable.
+     */
     public function testResolverIsTraversable()
     {
 
     }
 
+    /**
+     * Checks if the resolved set contains the initially provided entity classes.
+     */
     public function testSetContainsProvidedEntityClasses()
     {
 
     }
 
+    /**
+     * Checks if entities that are directly associated to the initially provided entities
+     * are contained in the resolved set.
+     */
     public function testSetContainsEntityClassesThatAreDirectlyConnectedToInitialSet()
     {
 
     }
 
+    /**
+     * Ensures that entities, which are connected via other associated entities,
+     * are contained in the generated set.
+     *
+     * Example:
+     *
+     *     A -> B -> C
+     */
     public function testSetContainsIndirectlyConnectedEntityClasses()
     {
 
     }
 
+    /**
+     * Ensures that the resolver can handle dependency cycles.
+     */
     public function testResolverCanHandleDependencyCycles()
     {
 

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * (c) webfactory GmbH <info@webfactory.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure;
+
+/**
+ * Tests the entity resolver.
+ */
+class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
+{
+    public function testResolverIsTraversable()
+    {
+
+    }
+
+    public function testSetContainsProvidedEntityClasses()
+    {
+
+    }
+
+    public function testSetContainsEntityClassesThatAreDirectlyConnectedToInitialSet()
+    {
+
+    }
+
+    public function testSetContainsIndirectlyConnectedEntityClasses()
+    {
+
+    }
+
+    public function testResolverCanHandleDependencyCycles()
+    {
+
+    }
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
@@ -110,6 +110,24 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Ensures that the resolver returns the entity class names without leading slash.
+     */
+    public function testResolvedSetContainsEntityClassesWithoutLeadingSlash()
+    {
+        $resolver = new EntityDependencyResolver(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ChainReferenceEntity'
+        ));
+
+        $resolvedSet = $this->getResolvedSet($resolver);
+
+        foreach ($resolvedSet as $entityClass) {
+            /* @var $entityClass string */
+            $message = 'Entity class name must be normalized and must not start with \\.';
+            $this->assertStringStartsNotWith('\\', $entityClass, $message);
+        }
+    }
+
+    /**
      * Returns the resolved set of entity classes as array.
      *
      * @param EntityDependencyResolver $resolver

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
@@ -258,4 +258,27 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
         $infrastructure->getEntityManager()->persist($entityWithDependency);
         $infrastructure->getEntityManager()->flush();
     }
+
+    /**
+     * Checks if the automatic dependency setup can cope with reference cycles,
+     * for example if an entity references itself.
+     */
+    public function testAutomaticDependencyDetectionCanHandleCycles()
+    {
+
+    }
+
+    /**
+     * Checks if the automatic dependency setup can cope with chained references.
+     *
+     * Example:
+     *
+     *     A -> B -> C
+     *
+     * A references B, B references C. A is not directly related to C.
+     */
+    public function testAutomaticDependencyDetectionCanHandleChainedRelations()
+    {
+
+    }
 }

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
@@ -309,7 +309,12 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreateWithDependenciesForCreatesInfrastructureForSetOfEntities()
     {
+        $infrastructure = ORMInfrastructure::createWithDependenciesFor(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity',
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity'
+        ));
 
+        $this->assertInstanceOf('\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure', $infrastructure);
     }
 
     /**
@@ -318,7 +323,11 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreateWithDependenciesForCreatesInfrastructureForSingleEntity()
     {
+        $infrastructure = ORMInfrastructure::createWithDependenciesFor(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity'
+        );
 
+        $this->assertInstanceOf('\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure', $infrastructure);
     }
 
     /**
@@ -327,7 +336,12 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreateOnlyForCreatesInfrastructureForSetOfEntities()
     {
+        $infrastructure = ORMInfrastructure::createOnlyFor(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity',
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity'
+        ));
 
+        $this->assertInstanceOf('\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure', $infrastructure);
     }
 
     /**
@@ -336,6 +350,10 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreateOnlyForCreatesInfrastructureForSingleEntity()
     {
+        $infrastructure = ORMInfrastructure::createOnlyFor(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity'
+        );
 
+        $this->assertInstanceOf('\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure', $infrastructure);
     }
 }

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
@@ -244,66 +244,6 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensures that referenced sub-entities are automatically prepared if the infrastructure is
-     * requested to handle such cases.
-     */
-    public function testInfrastructureAutomaticallyPerformsDependencySetupIfRequested()
-    {
-        $infrastructure = new ORMInfrastructure(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntityWithDependency'
-        ), true);
-
-        $entityWithDependency = new TestEntityWithDependency();
-
-        // Saving without prepared sub-entity would fail.
-        $this->setExpectedException(null);
-        $infrastructure->getEntityManager()->persist($entityWithDependency);
-        $infrastructure->getEntityManager()->flush();
-    }
-
-    /**
-     * Checks if the automatic dependency setup can cope with reference cycles,
-     * for example if an entity references itself.
-     */
-    public function testAutomaticDependencyDetectionCanHandleCycles()
-    {
-        $infrastructure = new ORMInfrastructure(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferenceCycleEntity'
-        ), true);
-
-        $entityWithCycle = new ReferenceCycleEntity();
-
-        // Saving will most probably work as no additional table is needed, but the reference
-        // detection, which is performed before, might lead to an endless loop.
-        $this->setExpectedException(null);
-        $infrastructure->getEntityManager()->persist($entityWithCycle);
-        $infrastructure->getEntityManager()->flush();
-    }
-
-    /**
-     * Checks if the automatic dependency setup can cope with chained references.
-     *
-     * Example:
-     *
-     *     A -> B -> C
-     *
-     * A references B, B references C. A is not directly related to C.
-     */
-    public function testAutomaticDependencyDetectionCanHandleChainedRelations()
-    {
-        $infrastructure = new ORMInfrastructure(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ChainReferenceEntity'
-        ), true);
-
-        $entityWithReferenceChain = new ChainReferenceEntity();
-
-        // All table must be created properly, otherwise it is not possible to store the entity.
-        $this->setExpectedException(null);
-        $infrastructure->getEntityManager()->persist($entityWithReferenceChain);
-        $infrastructure->getEntityManager()->flush();
-    }
-
-    /**
      * Ensures that createWithDependenciesFor() returns an infrastructure object if a set of
      * entities classes is provided.
      */
@@ -355,5 +295,65 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertInstanceOf('\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure', $infrastructure);
+    }
+
+    /**
+     * Ensures that referenced sub-entities are automatically prepared if the infrastructure is
+     * requested to handle such cases.
+     */
+    public function testInfrastructureAutomaticallyPerformsDependencySetupIfRequested()
+    {
+        $infrastructure = ORMInfrastructure::createWithDependenciesFor(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntityWithDependency'
+        ));
+
+        $entityWithDependency = new TestEntityWithDependency();
+
+        // Saving without prepared sub-entity would fail.
+        $this->setExpectedException(null);
+        $infrastructure->getEntityManager()->persist($entityWithDependency);
+        $infrastructure->getEntityManager()->flush();
+    }
+
+    /**
+     * Checks if the automatic dependency setup can cope with reference cycles,
+     * for example if an entity references itself.
+     */
+    public function testAutomaticDependencyDetectionCanHandleCycles()
+    {
+        $infrastructure = ORMInfrastructure::createWithDependenciesFor(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferenceCycleEntity'
+        ));
+
+        $entityWithCycle = new ReferenceCycleEntity();
+
+        // Saving will most probably work as no additional table is needed, but the reference
+        // detection, which is performed before, might lead to an endless loop.
+        $this->setExpectedException(null);
+        $infrastructure->getEntityManager()->persist($entityWithCycle);
+        $infrastructure->getEntityManager()->flush();
+    }
+
+    /**
+     * Checks if the automatic dependency setup can cope with chained references.
+     *
+     * Example:
+     *
+     *     A -> B -> C
+     *
+     * A references B, B references C. A is not directly related to C.
+     */
+    public function testAutomaticDependencyDetectionCanHandleChainedRelations()
+    {
+        $infrastructure = ORMInfrastructure::createWithDependenciesFor(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ChainReferenceEntity'
+        ));
+
+        $entityWithReferenceChain = new ChainReferenceEntity();
+
+        // All table must be created properly, otherwise it is not possible to store the entity.
+        $this->setExpectedException(null);
+        $infrastructure->getEntityManager()->persist($entityWithReferenceChain);
+        $infrastructure->getEntityManager()->flush();
     }
 }

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
@@ -302,4 +302,40 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
         $infrastructure->getEntityManager()->persist($entityWithReferenceChain);
         $infrastructure->getEntityManager()->flush();
     }
+
+    /**
+     * Ensures that createWithDependenciesFor() returns an infrastructure object if a set of
+     * entities classes is provided.
+     */
+    public function testCreateWithDependenciesForCreatesInfrastructureForSetOfEntities()
+    {
+
+    }
+
+    /**
+     * Ensures that createWithDependenciesFor() returns an infrastructure object if a single
+     * entity class is provided.
+     */
+    public function testCreateWithDependenciesForCreatesInfrastructureForSingleEntity()
+    {
+
+    }
+
+    /**
+     * Ensures that createOnlyFor() returns an infrastructure object if a set of
+     * entities classes is provided.
+     */
+    public function testCreateOnlyForCreatesInfrastructureForSetOfEntities()
+    {
+
+    }
+
+    /**
+     * Ensures that createOnlyFor() returns an infrastructure object if a single
+     * entity class is provided.
+     */
+    public function testCreateOnlyForCreatesInfrastructureForSingleEntity()
+    {
+
+    }
 }

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
@@ -9,6 +9,8 @@
 
 namespace Webfactory\Doctrine\ORMTestInfrastructure;
 
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ChainReferenceEntity;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferenceCycleEntity;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntityWithDependency;
 
@@ -265,7 +267,17 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
      */
     public function testAutomaticDependencyDetectionCanHandleCycles()
     {
+        $infrastructure = new ORMInfrastructure(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferenceCycleEntity'
+        ), true);
 
+        $entityWithCycle = new ReferenceCycleEntity();
+
+        // Saving will most probably work as no additional table is needed, but the reference
+        // detection, which is performed before, might lead to an endless loop.
+        $this->setExpectedException(null);
+        $infrastructure->getEntityManager()->persist($entityWithCycle);
+        $infrastructure->getEntityManager()->flush();
     }
 
     /**
@@ -279,6 +291,15 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
      */
     public function testAutomaticDependencyDetectionCanHandleChainedRelations()
     {
+        $infrastructure = new ORMInfrastructure(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ChainReferenceEntity'
+        ), true);
 
+        $entityWithReferenceChain = new ChainReferenceEntity();
+
+        // All table must be created properly, otherwise it is not possible to store the entity.
+        $this->setExpectedException(null);
+        $infrastructure->getEntityManager()->persist($entityWithReferenceChain);
+        $infrastructure->getEntityManager()->flush();
     }
 }

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
@@ -10,6 +10,7 @@
 namespace Webfactory\Doctrine\ORMTestInfrastructure;
 
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntityWithDependency;
 
 /**
  * Tests the infrastructure.
@@ -238,5 +239,23 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInternalType('array', $queries);
         $this->assertCount(1, $queries);
+    }
+
+    /**
+     * Ensures that referenced sub-entities are automatically prepared if the infrastructure is
+     * requested to handle such cases.
+     */
+    public function testInfrastructureAutomaticallyPerformsDependencySetupIfRequested()
+    {
+        $infrastructure = new ORMInfrastructure(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntityWithDependency'
+        ), true);
+
+        $entityWithDependency = new TestEntityWithDependency();
+
+        // Saving without prepared sub-entity would fail.
+        $this->setExpectedException(null);
+        $infrastructure->getEntityManager()->persist($entityWithDependency);
+        $infrastructure->getEntityManager()->flush();
     }
 }

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/ChainReferenceEntity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/ChainReferenceEntity.php
@@ -2,16 +2,14 @@
 
 namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest;
 
-use Doctrine\ORM\Mapping as ORM;
-
 /**
- * Test entity that references another entity and therefore implicitly depends
- * on it in test scenarios.
+ * Entity that references an entity indirectly (over another reference).
  *
- * @ORM\Entity()
- * @ORM\Table(name="test_entity_with_dependency")
+ * Reference chain:
+ *
+ *     ChainReferenceEntity -> TestEntityWithDependency -> ReferencedEntity
  */
-class TestEntityWithDependency
+class ChainReferenceEntity
 {
     /**
      * A unique ID.
@@ -26,17 +24,17 @@ class TestEntityWithDependency
     /**
      * Required reference to another entity.
      *
-     * @var ReferencedEntity
-     * @ORM\OneToOne(targetEntity="ReferencedEntity", cascade={"all"})
+     * @var TestEntityWithDependency
+     * @ORM\OneToOne(targetEntity="TestEntityWithDependency", cascade={"all"})
      * @ORM\JoinColumn(nullable=false)
      */
     protected $dependency = null;
 
     /**
-     * Automatically creates a reference on construction.
+     * Automatically adds a referenced entity on construction.
      */
     public function __construct()
     {
-        $this->dependency = new ReferencedEntity();
+        $this->dependency = new TestEntityWithDependency();
     }
 }

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/ChainReferenceEntity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/ChainReferenceEntity.php
@@ -2,12 +2,17 @@
 
 namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest;
 
+use Doctrine\ORM\Mapping as ORM;
+
 /**
  * Entity that references an entity indirectly (over another reference).
  *
  * Reference chain:
  *
  *     ChainReferenceEntity -> TestEntityWithDependency -> ReferencedEntity
+ *
+ * @ORM\Entity()
+ * @ORM\Table(name="test_chain_reference_entity")
  */
 class ChainReferenceEntity
 {

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/ReferenceCycleEntity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/ReferenceCycleEntity.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest;
+
+/**
+ * Entity with a minimal reference cycle.
+ */
+class ReferenceCycleEntity
+{
+    /**
+     * A unique ID.
+     *
+     * @var integer|null
+     * @ORM\Id
+     * @ORM\Column(type="integer", name="id")
+     * @ORM\GeneratedValue
+     */
+    public $id = null;
+
+    /**
+     * Reference to an entity of the same type (minimal cycle).
+     *
+     * @var ReferenceCycleEntity|null
+     * @ORM\OneToOne(targetEntity="ReferenceCycleEntity", cascade={"all"})
+     * @ORM\JoinColumn(nullable=true)
+     */
+    protected $referenceCycle = null;
+
+    /**
+     * Creates an entity that references the provided entity.
+     *
+     * @param ReferenceCycleEntity|null $entity
+     */
+    public function __construct(ReferenceCycleEntity $entity = null)
+    {
+        $this->referenceCycle = $entity;
+    }
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/ReferenceCycleEntity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/ReferenceCycleEntity.php
@@ -2,8 +2,13 @@
 
 namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest;
 
+use Doctrine\ORM\Mapping as ORM;
+
 /**
  * Entity with a minimal reference cycle.
+ *
+ * @ORM\Entity()
+ * @ORM\Table(name="test_reference_cycle_entity")
  */
 class ReferenceCycleEntity
 {

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/ReferencedEntity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/ReferencedEntity.php
@@ -12,5 +12,13 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class ReferencedEntity
 {
-
+    /**
+     * A unique ID.
+     *
+     * @var integer|null
+     * @ORM\Id
+     * @ORM\Column(type="integer", name="id")
+     * @ORM\GeneratedValue
+     */
+    public $id = null;
 }

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/ReferencedEntity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/ReferencedEntity.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * An entity that is referenced by another one.
+ *
+ * @ORM\Entity()
+ * @ORM\Table(name="referenced_entity")
+ */
+class ReferencedEntity
+{
+
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/TestEntity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/TestEntity.php
@@ -12,7 +12,6 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class TestEntity
 {
-
     /**
      * A unique ID.
      *

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/TestEntityWithDependency.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/TestEntityWithDependency.php
@@ -27,7 +27,7 @@ class TestEntityWithDependency
      * Required reference to another entity.
      *
      * @var ReferencedEntity
-     * @ORM\OneToOne(targetEntity="ReferencedEntity")
+     * @ORM\OneToOne(targetEntity="ReferencedEntity", cascade={"all"})
      * @ORM\JoinColumn(nullable=false)
      */
     protected $dependency = null;

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/TestEntityWithDependency.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/TestEntityWithDependency.php
@@ -28,7 +28,7 @@ class TestEntityWithDependency
      *
      * @var ReferencedEntity
      * @ORM\OneToOne(targetEntity="ReferencedEntity")
-     * @ORM\Column(nullable=false)
+     * @ORM\JoinColumn(nullable=false)
      */
     protected $dependency = null;
 

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/TestEntityWithDependency.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/TestEntityWithDependency.php
@@ -14,7 +14,29 @@ use Doctrine\ORM\Mapping as ORM;
 class TestEntityWithDependency
 {
     /**
+     * A unique ID.
+     *
+     * @var integer|null
+     * @ORM\Id
+     * @ORM\Column(type="integer", name="id")
+     * @ORM\GeneratedValue
+     */
+    public $id = null;
+
+    /**
+     * Required reference to another entity.
+     *
      * @var ReferencedEntity
+     * @ORM\OneToOne(targetEntity="ReferencedEntity")
+     * @ORM\Column(nullable=false)
      */
     protected $dependency = null;
+
+    /**
+     * Automatically creates a referenced
+     */
+    public function __construct()
+    {
+        $this->dependency = new ReferencedEntity();
+    }
 }

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/TestEntityWithDependency.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/TestEntityWithDependency.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Test entity that references another entity and therefore implicitly depends
+ * on it in test scenarios.
+ *
+ * @ORM\Entity()
+ * @ORM\Table(name="test_entity_with_dependency")
+ */
+class TestEntityWithDependency
+{
+    /**
+     * @var ReferencedEntity
+     */
+    protected $dependency = null;
+}


### PR DESCRIPTION
Option to automatically detect associated entities and include these in the infrastructure setup (fixes #4).

Example:

    $infrastructure = ORMInfrastructure::createWithDependenciesFor(array(
        'My\Entity\ClassName'
    ));

