### PR TITLE
Detect inheritance dependencies

### DIFF
--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolver.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolver.php
@@ -109,6 +109,12 @@ class EntityDependencyResolver implements \IteratorAggregate
                 $associatedEntity = $metadata->getAssociationTargetClass($name);
                 $associatedEntities[] = $metadata->fullyQualifiedClassName($associatedEntity);
             }
+            // Add parent classes that are involved in some kind of entity inheritance.
+            foreach ($this->reflectionService->getParentClasses($entityClass) as $parentClass) {
+                if (!$config->getMetadataDriverImpl()->isTransient($parentClass)) {
+                    $associatedEntities[] = $parentClass;
+                }
+            }
         }
         return array_unique($associatedEntities);
     }

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolver.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolver.php
@@ -104,11 +104,18 @@ class EntityDependencyResolver implements \IteratorAggregate
             $metadata = new ClassMetadata($entityClass);
             $metadata->initializeReflection($this->reflectionService);
             $config->getMetadataDriverImpl()->loadMetadataForClass($entityClass, $metadata);
+
             foreach ($metadata->getAssociationNames() as $name) {
                 /* @var $name string */
                 $associatedEntity = $metadata->getAssociationTargetClass($name);
                 $associatedEntities[] = $metadata->fullyQualifiedClassName($associatedEntity);
             }
+
+            if (count($metadata->discriminatorMap) > 0) {
+                $childClasses = array_values($metadata->discriminatorMap);
+                $associatedEntities = array_merge($associatedEntities, $childClasses);
+            }
+
             // Add parent classes that are involved in some kind of entity inheritance.
             foreach ($this->reflectionService->getParentClasses($entityClass) as $parentClass) {
                 if (!$config->getMetadataDriverImpl()->isTransient($parentClass)) {

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
@@ -191,6 +191,18 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Ensures that the resolved set contains the entities that are explicitly mentioned in
+     * a discriminator map.
+     *
+     * Doctrine uses the information from the discriminator map to generate its queries.
+     * Therefore, the tables on the mentioned entities must be generated in the tests.
+     */
+    public function testResolvedSetContainsNamesOfEntitiesThatAreMentionedInDiscriminatorMap()
+    {
+
+    }
+
+    /**
      * Returns the resolved set of entity classes as array.
      *
      * @param EntityDependencyResolver $resolver

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
@@ -132,7 +132,14 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testResolvedSetContainsNameOfClassTableInheritanceParent()
     {
+        $resolver = new EntityDependencyResolver(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\ClassTableChildEntity'
+        ));
 
+        $this->assertContainsEntity(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\ClassTableParentEntity',
+            $resolver
+        );
     }
 
     /**
@@ -141,7 +148,15 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testResolvedSetContainsNameOfClassThatIsReferencedByParentWithClassTableStrategy()
     {
+        $resolver = new EntityDependencyResolver(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance' .
+            '\ClassTableChildWithParentReferenceEntity'
+        ));
 
+        $this->assertContainsEntity(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity',
+            $resolver
+        );
     }
 
     /**
@@ -149,7 +164,30 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testResolvedSetContainsNameOfMappedSuperClass()
     {
+        $resolver = new EntityDependencyResolver(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\MappedSuperClassChild'
+        ));
 
+        $this->assertContainsEntity(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance' .
+            '\MappedSuperClassParentWithReference',
+            $resolver
+        );
+    }
+
+    /**
+     * Ensures that an entity, that is referenced by a mapped super class, is listed in the resolved set.
+     */
+    public function testResolvedSetContainsNameOfEntityThatIsReferencedByMappedSuperClass()
+    {
+        $resolver = new EntityDependencyResolver(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\MappedSuperClassChild'
+        ));
+
+        $this->assertContainsEntity(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity',
+            $resolver
+        );
     }
 
     /**

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
@@ -199,7 +199,14 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testResolvedSetContainsNamesOfEntitiesThatAreMentionedInDiscriminatorMap()
     {
+        $resolver = new EntityDependencyResolver(array(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\DiscriminatorMapEntity'
+        ));
 
+        $this->assertContainsEntity(
+            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\DiscriminatorMapChildEntity',
+            $resolver
+        );
     }
 
     /**

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
@@ -128,6 +128,31 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Ensures that a parent that uses class table inheritance is listed in the resolved set.
+     */
+    public function testResolvedSetContainsNameOfClassTableInheritanceParent()
+    {
+
+    }
+
+    /**
+     * Ensures that the resolved set contains an entity class that is referenced by a parent
+     * entity (with class table inheritance strategy).
+     */
+    public function testResolvedSetContainsNameOfClassThatIsReferencedByParentWithClassTableStrategy()
+    {
+
+    }
+
+    /**
+     * Ensures that a mapped super class is listed in the resolved set.
+     */
+    public function testResolvedSetContainsNameOfMappedSuperClass()
+    {
+
+    }
+
+    /**
      * Returns the resolved set of entity classes as array.
      *
      * @param EntityDependencyResolver $resolver

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/ClassTableChildEntity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/ClassTableChildEntity.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Child class that uses class table inheritance.
+ *
+ * @ORM\Entity()
+ * @ORM\Table(name="class_inheritance_child")
+ * @see http://doctrine-orm.readthedocs.org/en/latest/reference/inheritance-mapping.html#class-table-inheritance
+ */
+class ClassTableChildEntity extends ClassTableParentEntity
+{
+    /**
+     * @var string
+     * @ORM\Column(type="string", name="child_name", nullable=false)
+     */
+    public $childName = 'child-name';
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/ClassTableChildWithParentReferenceEntity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/ClassTableChildWithParentReferenceEntity.php
@@ -9,7 +9,7 @@ namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheri
  * @ORM\Table(name="class_inheritance_with_reference_child")
  * @see http://doctrine-orm.readthedocs.org/en/latest/reference/inheritance-mapping.html#class-table-inheritance
  */
-class ClassTableChildWithParentReferenceEntity
+class ClassTableChildWithParentReferenceEntity extends ClassTableParentWithReferenceEntity
 {
     /**
      * @var string

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/ClassTableChildWithParentReferenceEntity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/ClassTableChildWithParentReferenceEntity.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance;
+
+/**
+ * Child class that uses class table inheritance with a parent that references another entity.
+ *
+ * @ORM\Entity()
+ * @ORM\Table(name="class_inheritance_with_reference_child")
+ * @see http://doctrine-orm.readthedocs.org/en/latest/reference/inheritance-mapping.html#class-table-inheritance
+ */
+class ClassTableChildWithParentReferenceEntity
+{
+    /**
+     * @var string
+     * @ORM\Column(type="string", name="child_name", nullable=false)
+     */
+    public $childName = 'child-name';
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/ClassTableChildWithParentReferenceEntity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/ClassTableChildWithParentReferenceEntity.php
@@ -2,6 +2,8 @@
 
 namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance;
 
+use Doctrine\ORM\Mapping as ORM;
+
 /**
  * Child class that uses class table inheritance with a parent that references another entity.
  *

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/ClassTableParentEntity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/ClassTableParentEntity.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Base class for entities with class table strategy.
+ *
+ * @ORM\Entity()
+ * @ORM\Table(name="class_inheritance_parent")
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorColumn(name="class", type="string")
+ * @see http://doctrine-orm.readthedocs.org/en/latest/reference/inheritance-mapping.html#class-table-inheritance
+ */
+abstract class ClassTableParentEntity
+{
+    /**
+     * A unique ID.
+     *
+     * @var integer|null
+     * @ORM\Id
+     * @ORM\Column(type="integer", name="id")
+     * @ORM\GeneratedValue
+     */
+    public $id = null;
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/ClassTableParentWithReferenceEntity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/ClassTableParentWithReferenceEntity.php
@@ -32,7 +32,10 @@ abstract class ClassTableParentWithReferenceEntity
      * Required reference to another entity.
      *
      * @var ReferencedEntity
-     * @ORM\OneToOne(targetEntity="ReferencedEntity", cascade={"all"})
+     * @ORM\OneToOne(
+     *     targetEntity="\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity",
+     *     cascade={"all"}
+     * )
      * @ORM\JoinColumn(nullable=false)
      */
     protected $dependency = null;

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/ClassTableParentWithReferenceEntity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/ClassTableParentWithReferenceEntity.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance;
+
+use Doctrine\ORM\Mapping as ORM;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity;
+
+/**
+ * Base class for entities with class table strategy.
+ *
+ * References another entity. This dependency is inherited by all children.
+ *
+ * @ORM\Entity()
+ * @ORM\Table(name="class_inheritance_with_reference_parent")
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorColumn(name="class", type="string")
+ * @see http://doctrine-orm.readthedocs.org/en/latest/reference/inheritance-mapping.html#class-table-inheritance
+ */
+abstract class ClassTableParentWithReferenceEntity
+{
+    /**
+     * A unique ID.
+     *
+     * @var integer|null
+     * @ORM\Id
+     * @ORM\Column(type="integer", name="id")
+     * @ORM\GeneratedValue
+     */
+    public $id = null;
+
+    /**
+     * Required reference to another entity.
+     *
+     * @var ReferencedEntity
+     * @ORM\OneToOne(targetEntity="ReferencedEntity", cascade={"all"})
+     * @ORM\JoinColumn(nullable=false)
+     */
+    protected $dependency = null;
+
+    /**
+     * Automatically creates a reference on construction.
+     */
+    public function __construct()
+    {
+        $this->dependency = new ReferencedEntity();
+    }
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/DiscriminatorMapChildEntity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/DiscriminatorMapChildEntity.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class DiscriminatorMapChildEntity extends DiscriminatorMapEntity
+{
+    /**
+     * @var string
+     * @ORM\Column(type="string", name="child_name", nullable=false)
+     */
+    public $childName = 'child-name';
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/DiscriminatorMapEntity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/DiscriminatorMapEntity.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Base entity with an explicit discriminator map.
+ *
+ * The discriminator map contains fully qualified as well as relative entity class names.
+ *
+ * @ORM\Entity()
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorColumn(name="type", type="string")
+ * @ORM\DiscriminatorMap({
+ *     "parent" = "\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\DiscriminatorMapEntity",
+ *     "child" = "DiscriminatorMapChildEntity"
+ * })
+ * @see http://doctrine-orm.readthedocs.org/en/latest/reference/inheritance-mapping.html#class-table-inheritance
+ */
+class DiscriminatorMapEntity
+{
+    /**
+     * A unique ID.
+     *
+     * @var integer|null
+     * @ORM\Id
+     * @ORM\Column(type="integer", name="id")
+     * @ORM\GeneratedValue
+     */
+    public $id = null;
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/MappedSuperClassChild.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/MappedSuperClassChild.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class MappedSuperClassChild extends MappedSuperClassParentWithReference
+{
+    /**
+     * @var string
+     * @ORM\Column(type="string", name="child_name", nullable=false)
+     */
+    public $childName = 'child-name';
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/MappedSuperClassParentWithReference.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/MappedSuperClassParentWithReference.php
@@ -17,7 +17,10 @@ abstract class MappedSuperClassParentWithReference
      * Required reference to another entity.
      *
      * @var ReferencedEntity
-     * @ORM\OneToOne(targetEntity="ReferencedEntity", cascade={"all"})
+     * @ORM\OneToOne(
+     *     targetEntity="\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity",
+     *     cascade={"all"}
+     * )
      * @ORM\JoinColumn(nullable=false)
      */
     protected $dependency = null;

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/MappedSuperClassParentWithReference.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Inheritance/MappedSuperClassParentWithReference.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance;
+
+use Doctrine\ORM\Mapping as ORM;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity;
+
+/**
+ * Mapped super class that references another entity.
+ *
+ * @ORM\MappedSuperclass()
+ * @see http://doctrine-orm.readthedocs.org/en/latest/reference/inheritance-mapping.html#mapped-superclasses
+ */
+abstract class MappedSuperClassParentWithReference
+{
+    /**
+     * Required reference to another entity.
+     *
+     * @var ReferencedEntity
+     * @ORM\OneToOne(targetEntity="ReferencedEntity", cascade={"all"})
+     * @ORM\JoinColumn(nullable=false)
+     */
+    protected $dependency = null;
+
+    /**
+     * Automatically creates a reference on construction.
+     */
+    public function __construct()
+    {
+        $this->dependency = new ReferencedEntity();
+    }
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/README.md
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/README.md
@@ -1,0 +1,8 @@
+# Autoloading of Test Classes #
+
+Autoloading for the test classes in this directory is configured as class map (only available in dev mode).
+Therefore, the class map must be regenerated whenever test classes are added here:
+
+    php composer.phar install
+
+If this step is omitted, autoloading of recently added test classes will fail.


### PR DESCRIPTION
Simulate parent entities and entities that are mentioned in a discrimnator map (fixes #9).