### PR TITLE
Avoid circular reference in ORMInfrastructure

### DIFF
--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
@@ -296,9 +296,18 @@ class ORMInfrastructure
      */
     protected function createAnnotationLoader()
     {
-        return function ($annotationClass) {
+        $loader = function ($annotationClass) {
             return class_exists($annotationClass, true);
         };
+        if (method_exists($loader, 'bindTo')) {
+            // Starting with PHP 5.4, the object context is bound to created closures. The context is not needed
+            // in the function above and as we will store the function in an attribute, this would create a
+            // circular reference between object and function. That would delay the garbage collection and
+            // the cleanup that happens in __destruct.
+            // To avoid these issues, we simply remove the context from the lambda function.
+            $loader = $loader->bindTo(null);
+        }
+        return $loader;
     }
 
     /**

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
@@ -379,4 +379,50 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
             $entities
         );
     }
+
+    /**
+     * This test checks if a ORMInfrastructure object is immediately destructed when external references are removed.
+     *
+     * This ensures that the cleanup process runs early and the test environment is not polluted with infrastructure
+     * objects hanging in memory until the tests end.
+     * This is not a perfect test as it relies on internal knowledge about the magic of infrastructure. However,
+     * at the moment it is at least a viable solution.
+     */
+    public function testInfrastructureIsImmediatelyDestructed()
+    {
+        $beforeCreation = $this->getNumberOfAnnotationLoaders();
+        $infrastructure = ORMInfrastructure::createOnlyFor(
+            'Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity'
+        );
+        $afterCreation = $this->getNumberOfAnnotationLoaders();
+        $this->assertEquals(
+            $beforeCreation + 1,
+            $afterCreation,
+            'This test assumes that each infrastructure add an annotation loader. ' .
+            'It will not work if this prerequisite is not met.'
+        );
+
+        // Remove reference to the infrastructure object.
+        unset($infrastructure);
+
+        $afterDestruction = $this->getNumberOfAnnotationLoaders();
+        $this->assertEquals(
+            $beforeCreation,
+            $afterDestruction,
+            'Expected annotation loader to be immediately removed, which should happen in __destruct().'
+        );
+    }
+
+    /**
+     * Returns the number of currently registered annotation loaders.
+     *
+     * @return integer
+     */
+    private function getNumberOfAnnotationLoaders()
+    {
+        $reflection = new \ReflectionClass('\Doctrine\Common\Annotations\AnnotationRegistry');
+        $annotationLoaderProperty = $reflection->getProperty('loaders');
+        $annotationLoaderProperty->setAccessible(true);
+        return count($annotationLoaderProperty->getValue());
+    }
 }


### PR DESCRIPTION
Avoid a circular reference, which ensures immediate cleanup after each test run.