### PR TITLE
Check entity classes on infrastructure creation

### DIFF
--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
@@ -169,6 +169,7 @@ class ORMInfrastructure
         if ($entityClasses instanceof \Traversable) {
             $entityClasses = iterator_to_array($entityClasses);
         }
+        $this->assertClassNames($entityClasses);
         $this->entityClasses    = $entityClasses;
         $this->annotationLoader = $this->createAnnotationLoader();
         $this->queryLogger      = new DebugStack();
@@ -340,5 +341,22 @@ class ORMInfrastructure
             }
         }
         $annotationLoaderProperty->setValue(array_values($activeLoaders));
+    }
+
+    /**
+     * Checks if all entries in the given list are names of existing classes.
+     *
+     * @param string[] $classes
+     * @throws \InvalidArgumentException If an entry is not a valid class name.
+     */
+    private function assertClassNames(array $classes)
+    {
+        foreach ($classes as $class) {
+            if (class_exists($class, true)) {
+                continue;
+            }
+            $message = sprintf('"%s" is no existing class. Did you configure your autoloader correctly?', $class);
+            throw new \InvalidArgumentException($message);
+        }
     }
 }

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
@@ -90,6 +90,15 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Ensure that the infrastructure fails fast if obviously invalid data is passed.
+     */
+    public function testInfrastructureRejectsNonClassNames()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+        ORMInfrastructure::createOnlyFor(array('NotAClass'));
+    }
+
+    /**
      * Checks if import() adds entities to the database.
      *
      * There are different options to import entities, but these are handled in detail


### PR DESCRIPTION
Checks if at least valid class names are provided on infrastructure creation. 
Fail fast if that is not the case (most probably misspelled or class loader not working as expected).