### PR TITLE
Interface associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ Happy testing!
 
 ## Changelog ##
 
+### 1.4.5 -> 1.4.6 ###
+
+- ignore associations against interfaces when detecting dependencies via ``ORMInfrastructure::createWithDependenciesFor`` to avoid errors
+- exposed event manager and created helper method to be able to register entity mappings
+
+
+Register entity type mapping:
+
+    $infrastructure->registerEntityMapping(EntityInterface::class, EntityImplementation::class);
+
+Do not rely on this "feature" if you don't have to. Might be restructured in future versions.
+
 ### 1.4.4 -> 1.4.5 ###
 
 - fixed bug [#20](https://github.com/webfactory/doctrine-orm-test-infrastructure/issues/20): Entities might have been imported twice in case of bidirectional cascade

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
@@ -281,12 +281,18 @@ class ORMInfrastructure
      *
      * @param string $originalEntity
      * @param string $targetEntity
+     * @throws \LogicException If you call this method after using the infrastructure.
      * @internal Might be replaced in the future by a more advanced config system.
      *           Do not rely on this feature if you don't have to.
      * @see http://symfony.com/doc/current/doctrine/resolve_target_entity.html#set-up
      */
     public function registerEntityMapping($originalEntity, $targetEntity)
     {
+        if ($this->entityManager !== null) {
+            $message = 'Call %s() before using the entity manager or importing data. '
+                . 'Otherwise your entity mapping might not take effect.';
+            throw new \LogicException(sprintf($message, __FUNCTION__));
+        }
         $this->getResolveTargetListener()->addResolveTargetEntity($originalEntity, $targetEntity, array());
     }
 

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
@@ -9,12 +9,16 @@
 
 namespace Webfactory\Doctrine\ORMTestInfrastructure;
 
+use Doctrine\Common\EventManager;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\DBAL\Logging\DebugStack;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
+use Doctrine\ORM\Tools\ResolveTargetEntityListener;
 use Doctrine\ORM\Tools\SchemaTool;
+use \Doctrine\Common\EventSubscriber;
 
 /**
  * Helper class that creates the database infrastructure for a defined set of entity classes.
@@ -117,6 +121,20 @@ class ORMInfrastructure
     protected $configFactory = null;
 
     /**
+     * @var EventManager
+     */
+    private $eventManager;
+
+    /**
+     * Listener that is used to resolve entity mappings.
+     *
+     * Null if the listener is not registered yet.
+     *
+     * @var ResolveTargetEntityListener|null
+     */
+    private $resolveTargetListener;
+
+    /**
      * Creates an infrastructure for the given entity or entities, including all
      * referenced entities.
      *
@@ -178,7 +196,7 @@ class ORMInfrastructure
         $this->entityClasses = $entityClasses;
         $this->queryLogger   = new DebugStack();
         $this->configFactory = new ConfigurationFactory();
-
+        $this->eventManager  = new EventManager();
     }
 
     /**
@@ -244,6 +262,35 @@ class ORMInfrastructure
     }
 
     /**
+     * Returns the event manager that will be used by the entity manager.
+     *
+     * Can be used to register type mappings for interfaces.
+     *
+     * @return EventManager
+     * @internal Do not rely on this method if you don't have to. Might be removed in future versions.
+     */
+    public function getEventManager()
+    {
+        return $this->eventManager;
+    }
+
+    /**
+     * Registers a type mapping.
+     *
+     * Might be required if you define an association mapping against an interface.
+     *
+     * @param string $originalEntity
+     * @param string $targetEntity
+     * @internal Might be replaced in the future by a more advanced config system.
+     *           Do not rely on this feature if you don't have to.
+     * @see http://symfony.com/doc/current/doctrine/resolve_target_entity.html#set-up
+     */
+    public function registerEntityMapping($originalEntity, $targetEntity)
+    {
+        $this->getResolveTargetListener()->addResolveTargetEntity($originalEntity, $targetEntity, array());
+    }
+
+    /**
      * Creates a new entity manager.
      *
      * @return \Doctrine\ORM\EntityManager
@@ -252,7 +299,7 @@ class ORMInfrastructure
     {
         $config = $this->configFactory->createFor($this->entityClasses);
         $config->setSQLLogger($this->queryLogger);
-        return EntityManager::create($this->defaultConnectionParams, $config);
+        return EntityManager::create($this->defaultConnectionParams, $config, $this->eventManager);
     }
 
     /**
@@ -345,6 +392,28 @@ class ORMInfrastructure
             }
         }
         $annotationLoaderProperty->setValue(array_values($activeLoaders));
+    }
+
+    /**
+     * Returns the listener that is used to apply entity mappings.
+     *
+     * Registers one if none is configured yet.
+     *
+     * @return ResolveTargetEntityListener
+     */
+    private function getResolveTargetListener()
+    {
+        if ($this->resolveTargetListener === null) {
+            $this->resolveTargetListener = new ResolveTargetEntityListener();
+            if ($this->resolveTargetListener instanceof EventSubscriber) {
+                // In Doctrine > 2.5 this is a event subscriber.
+                $this->getEventManager()->addEventSubscriber($this->resolveTargetListener);
+            } else {
+                // In previous versions the listener must be attached "manually".
+                $this->getEventManager()->addEventListener(Events::loadClassMetadata, $this->resolveTargetListener);
+            }
+        }
+        return $this->resolveTargetListener;
     }
 
     /**

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
@@ -9,6 +9,19 @@
 
 namespace Webfactory\Doctrine\ORMTestInfrastructure;
 
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ChainReferenceEntity;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\ClassTableChildEntity;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\ClassTableChildWithParentReferenceEntity;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\ClassTableParentEntity;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\DiscriminatorMapChildEntity;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\DiscriminatorMapEntity;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\MappedSuperClassChild;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\MappedSuperClassParentWithReference;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferenceCycleEntity;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntityWithDependency;
+
 /**
  * Tests the entity resolver.
  */
@@ -20,7 +33,7 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
     public function testResolverIsTraversable()
     {
         $resolver = new EntityDependencyResolver(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity'
+            TestEntity::class
         ));
 
         $this->assertInstanceOf('\Traversable', $resolver);
@@ -32,11 +45,11 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
     public function testSetContainsProvidedEntityClasses()
     {
         $resolver = new EntityDependencyResolver(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity'
+            TestEntity::class
         ));
 
         $this->assertContainsEntity(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity',
+            TestEntity::class,
             $resolver
         );
     }
@@ -48,11 +61,11 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
     public function testSetContainsEntityClassesThatAreDirectlyConnectedToInitialSet()
     {
         $resolver = new EntityDependencyResolver(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntityWithDependency'
+            TestEntityWithDependency::class
         ));
 
         $this->assertContainsEntity(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity',
+            ReferencedEntity::class,
             $resolver
         );
     }
@@ -68,11 +81,11 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
     public function testSetContainsIndirectlyConnectedEntityClasses()
     {
         $resolver = new EntityDependencyResolver(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ChainReferenceEntity'
+            ChainReferenceEntity::class
         ));
 
         $this->assertContainsEntity(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity',
+            ReferencedEntity::class,
             $resolver
         );
     }
@@ -83,11 +96,11 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
     public function testResolverCanHandleDependencyCycles()
     {
         $resolver = new EntityDependencyResolver(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferenceCycleEntity'
+            ReferenceCycleEntity::class
         ));
 
         $this->assertContainsEntity(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferenceCycleEntity',
+            ReferenceCycleEntity::class,
             $resolver
         );
     }
@@ -98,7 +111,7 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
     public function testSetContainsEntitiesOnlyOnce()
     {
         $resolver = new EntityDependencyResolver(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferenceCycleEntity'
+            ReferenceCycleEntity::class
         ));
 
         $resolvedSet = $this->getResolvedSet($resolver);
@@ -115,7 +128,7 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
     public function testResolvedSetContainsEntityClassesWithoutLeadingSlash()
     {
         $resolver = new EntityDependencyResolver(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ChainReferenceEntity'
+            ChainReferenceEntity::class
         ));
 
         $resolvedSet = $this->getResolvedSet($resolver);
@@ -133,11 +146,11 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
     public function testResolvedSetContainsNameOfClassTableInheritanceParent()
     {
         $resolver = new EntityDependencyResolver(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\ClassTableChildEntity'
+            ClassTableChildEntity::class
         ));
 
         $this->assertContainsEntity(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\ClassTableParentEntity',
+            ClassTableParentEntity::class,
             $resolver
         );
     }
@@ -149,12 +162,11 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
     public function testResolvedSetContainsNameOfClassThatIsReferencedByParentWithClassTableStrategy()
     {
         $resolver = new EntityDependencyResolver(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance' .
-            '\ClassTableChildWithParentReferenceEntity'
+            ClassTableChildWithParentReferenceEntity::class
         ));
 
         $this->assertContainsEntity(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity',
+            ReferencedEntity::class,
             $resolver
         );
     }
@@ -165,12 +177,11 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
     public function testResolvedSetContainsNameOfMappedSuperClass()
     {
         $resolver = new EntityDependencyResolver(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\MappedSuperClassChild'
+            MappedSuperClassChild::class
         ));
 
         $this->assertContainsEntity(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance' .
-            '\MappedSuperClassParentWithReference',
+            MappedSuperClassParentWithReference::class,
             $resolver
         );
     }
@@ -181,11 +192,11 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
     public function testResolvedSetContainsNameOfEntityThatIsReferencedByMappedSuperClass()
     {
         $resolver = new EntityDependencyResolver(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\MappedSuperClassChild'
+            MappedSuperClassChild::class
         ));
 
         $this->assertContainsEntity(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity',
+            ReferencedEntity::class,
             $resolver
         );
     }
@@ -200,11 +211,11 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
     public function testResolvedSetContainsNamesOfEntitiesThatAreMentionedInDiscriminatorMap()
     {
         $resolver = new EntityDependencyResolver(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\DiscriminatorMapEntity'
+            DiscriminatorMapEntity::class
         ));
 
         $this->assertContainsEntity(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\DiscriminatorMapChildEntity',
+            DiscriminatorMapChildEntity::class,
             $resolver
         );
     }
@@ -217,7 +228,7 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
      */
     protected function getResolvedSet(EntityDependencyResolver $resolver)
     {
-        $this->assertInstanceOf('\Traversable', $resolver);
+        $this->assertInstanceOf(\Traversable::class, $resolver);
         $entities = iterator_to_array($resolver);
         $this->assertContainsOnly('string', $entities);
         return $entities;

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
@@ -17,6 +17,8 @@ use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\DiscriminatorMapEntity;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\MappedSuperClassChild;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Inheritance\MappedSuperClassParentWithReference;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\InterfaceAssociation\EntityInterface;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\InterfaceAssociation\EntityWithAssociationAgainstInterface;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferenceCycleEntity;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity;
@@ -218,6 +220,19 @@ class EntityDependencyResolverTest extends \PHPUnit_Framework_TestCase
             DiscriminatorMapChildEntity::class,
             $resolver
         );
+    }
+
+    /**
+     * Interfaces can be used as association targets, but this simple resolver cannot handle them.
+     * Nevertheless, the resolver should not fail and the interfaces should not show up in the dependency list.
+     */
+    public function testResolvedSetDoesNotContainInterfaces()
+    {
+        $resolver = new EntityDependencyResolver([
+            EntityWithAssociationAgainstInterface::class
+        ]);
+
+        $this->assertNotContains(EntityInterface::class, $this->getResolvedSet($resolver));
     }
 
     /**

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
@@ -9,13 +9,17 @@
 
 namespace Webfactory\Doctrine\ORMTestInfrastructure;
 
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\AnnotatedTestEntity;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Annotation\AnnotationForTestWithDependencyDiscovery;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\AnnotatedTestEntityForDependencyDiscovery;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ChainReferenceEntity;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferenceCycleEntity;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntityRepository;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntityWithDependency;
 
 /**
@@ -38,7 +42,7 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
         $this->infrastructure = new ORMInfrastructure(array(
-            'Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity'
+            TestEntity::class
         ));
     }
 
@@ -58,7 +62,7 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
     {
         $entityManager = $this->infrastructure->getEntityManager();
 
-        $this->assertInstanceOf('Doctrine\ORM\EntityManager', $entityManager);
+        $this->assertInstanceOf(EntityManager::class, $entityManager);
     }
 
     /**
@@ -68,11 +72,11 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
     public function testGetRepositoryReturnsRepositoryThatBelongsToEntityClass()
     {
         $repository = $this->infrastructure->getRepository(
-            'Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity'
+            TestEntity::class
         );
 
         $this->assertInstanceOf(
-            'Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntityRepository',
+            TestEntityRepository::class,
             $repository
         );
     }
@@ -87,7 +91,7 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
         $repository = $this->infrastructure->getRepository($entity);
 
         $this->assertInstanceOf(
-            'Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntityRepository',
+            TestEntityRepository::class,
             $repository
         );
     }
@@ -148,7 +152,7 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
 
         $loadedEntity = $repository->find($entity->id);
         $this->assertInstanceOf(
-            'Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity',
+            TestEntity::class,
             $loadedEntity
         );
         $this->assertNotSame($entity, $loadedEntity);
@@ -161,7 +165,7 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
     {
         $entity = new TestEntity();
         $anotherInfrastructure = new ORMInfrastructure(array(
-            'Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity'
+            TestEntity::class
         ));
         $repository = $anotherInfrastructure->getRepository($entity);
 
@@ -195,7 +199,7 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
         $queries = $this->infrastructure->getQueries();
 
         $this->assertInternalType('array', $queries);
-        $this->assertContainsOnly('\Webfactory\Doctrine\ORMTestInfrastructure\Query', $queries);
+        $this->assertContainsOnly(Query::class, $queries);
     }
 
     /**
@@ -250,11 +254,11 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
     public function testCreateWithDependenciesForCreatesInfrastructureForSetOfEntities()
     {
         $infrastructure = ORMInfrastructure::createWithDependenciesFor(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity',
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity'
+            TestEntity::class,
+            ReferencedEntity::class
         ));
 
-        $this->assertInstanceOf('\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure', $infrastructure);
+        $this->assertInstanceOf(ORMInfrastructure::class, $infrastructure);
     }
 
     /**
@@ -264,10 +268,10 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
     public function testCreateWithDependenciesForCreatesInfrastructureForSingleEntity()
     {
         $infrastructure = ORMInfrastructure::createWithDependenciesFor(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity'
+            TestEntity::class
         );
 
-        $this->assertInstanceOf('\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure', $infrastructure);
+        $this->assertInstanceOf(ORMInfrastructure::class, $infrastructure);
     }
 
     /**
@@ -277,11 +281,11 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
     public function testCreateOnlyForCreatesInfrastructureForSetOfEntities()
     {
         $infrastructure = ORMInfrastructure::createOnlyFor(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity',
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity'
+            TestEntity::class,
+            ReferencedEntity::class
         ));
 
-        $this->assertInstanceOf('\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure', $infrastructure);
+        $this->assertInstanceOf(ORMInfrastructure::class, $infrastructure);
     }
 
     /**
@@ -291,10 +295,10 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
     public function testCreateOnlyForCreatesInfrastructureForSingleEntity()
     {
         $infrastructure = ORMInfrastructure::createOnlyFor(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity'
+            TestEntity::class
         );
 
-        $this->assertInstanceOf('\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure', $infrastructure);
+        $this->assertInstanceOf(ORMInfrastructure::class, $infrastructure);
     }
 
     /**
@@ -304,7 +308,7 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
     public function testInfrastructureAutomaticallyPerformsDependencySetupIfRequested()
     {
         $infrastructure = ORMInfrastructure::createWithDependenciesFor(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntityWithDependency'
+            TestEntityWithDependency::class
         ));
 
         $entityWithDependency = new TestEntityWithDependency();
@@ -322,7 +326,7 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
     public function testAutomaticDependencyDetectionCanHandleCycles()
     {
         $infrastructure = ORMInfrastructure::createWithDependenciesFor(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferenceCycleEntity'
+            ReferenceCycleEntity::class
         ));
 
         $entityWithCycle = new ReferenceCycleEntity();
@@ -346,7 +350,7 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
     public function testAutomaticDependencyDetectionCanHandleChainedRelations()
     {
         $infrastructure = ORMInfrastructure::createWithDependenciesFor(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ChainReferenceEntity'
+            ChainReferenceEntity::class
         ));
 
         $entityWithReferenceChain = new ChainReferenceEntity();
@@ -366,7 +370,7 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
     public function testNotSimulatedEntitiesAreNotExposed()
     {
         $infrastructure = ORMInfrastructure::createOnlyFor(array(
-            '\Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity'
+            TestEntity::class
         ));
 
         $metadata = $infrastructure->getEntityManager()->getMetadataFactory()->getAllMetadata();
@@ -374,7 +378,7 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
             return ltrim($info->name, '\\');
         }, $metadata);
         $this->assertEquals(
-            array('Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity'),
+            array(TestEntity::class),
             $entities
         );
     }
@@ -391,7 +395,7 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
     {
         $beforeCreation = $this->getNumberOfAnnotationLoaders();
         $infrastructure = ORMInfrastructure::createOnlyFor(
-            'Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity'
+            TestEntity::class
         );
         $afterCreation = $this->getNumberOfAnnotationLoaders();
         $this->assertEquals(
@@ -478,7 +482,7 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
      */
     private function getNumberOfAnnotationLoaders()
     {
-        $reflection = new \ReflectionClass('\Doctrine\Common\Annotations\AnnotationRegistry');
+        $reflection = new \ReflectionClass(AnnotationRegistry::class);
         $annotationLoaderProperty = $reflection->getProperty('loaders');
         $annotationLoaderProperty->setAccessible(true);
         return count($annotationLoaderProperty->getValue());

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
@@ -502,6 +502,14 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
         $infrastructure->getEntityManager();
     }
 
+    public function testCannotRegisterEntityMappingAfterEntityManagerCreation()
+    {
+        $this->infrastructure->getEntityManager();
+
+        $this->setExpectedException(\LogicException::class);
+        $this->infrastructure->registerEntityMapping(EntityInterface::class, EntityImplementation::class);
+    }
+
     /**
      * Returns the number of currently registered annotation loaders.
      *

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
@@ -10,12 +10,16 @@
 namespace Webfactory\Doctrine\ORMTestInfrastructure;
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Common\EventManager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\AnnotatedTestEntity;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Annotation\AnnotationForTestWithDependencyDiscovery;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\AnnotatedTestEntityForDependencyDiscovery;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ChainReferenceEntity;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\EntityImplementation;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\InterfaceAssociation\EntityInterface;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\InterfaceAssociation\EntityWithAssociationAgainstInterface;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferenceCycleEntity;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ReferencedEntity;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity;
@@ -473,6 +477,29 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
         ORMInfrastructure::createWithDependenciesFor(
             AnnotatedTestEntityForDependencyDiscovery::class
         );
+    }
+
+    public function testGetEventManagerReturnsEventManager()
+    {
+        $this->assertInstanceOf(EventManager::class, $this->infrastructure->getEventManager());
+    }
+
+    public function testGetEventManagerReturnsSameEventManagerThatIsUsedByEntityManager()
+    {
+        $this->assertSame(
+            $this->infrastructure->getEventManager(),
+            $this->infrastructure->getEntityManager()->getEventManager()
+        );
+    }
+
+    public function testCanHandleInterfaceAssociationsIfMappingIsProvided()
+    {
+        $infrastructure = ORMInfrastructure::createWithDependenciesFor(EntityWithAssociationAgainstInterface::class);
+
+        $infrastructure->registerEntityMapping(EntityInterface::class, EntityImplementation::class);
+
+        $this->setExpectedException(null);
+        $infrastructure->getEntityManager();
     }
 
     /**

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/InterfaceAssociation/EntityImplementation.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/InterfaceAssociation/EntityImplementation.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest;
+
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\InterfaceAssociation\EntityInterface;
+
+/**
+ * Implements an interface that is used in an association.
+ */
+class EntityImplementation implements EntityInterface
+{
+    /**
+     * A unique ID.
+     *
+     * @var integer|null
+     * @ORM\Id
+     * @ORM\Column(type="integer", name="id")
+     * @ORM\GeneratedValue
+     */
+    public $id = null;
+
+    /**
+     * Dummy function.
+     *
+     * @return integer
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/InterfaceAssociation/EntityImplementation.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/InterfaceAssociation/EntityImplementation.php
@@ -3,9 +3,13 @@
 namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest;
 
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\InterfaceAssociation\EntityInterface;
+use Doctrine\ORM\Mapping as ORM;
 
 /**
  * Implements an interface that is used in an association.
+ *
+ * @ORM\Entity()
+ * @ORM\Table(name="entity_implementing_referenced_interface")
  */
 class EntityImplementation implements EntityInterface
 {

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/InterfaceAssociation/EntityInterface.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/InterfaceAssociation/EntityInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\InterfaceAssociation;
+
+/**
+ * Interface that is used as target in an association.
+ */
+interface EntityInterface
+{
+    /**
+     * Dummy function.
+     *
+     * @return integer
+     */
+    public function getId();
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/InterfaceAssociation/EntityWithAssociationAgainstInterface.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/InterfaceAssociation/EntityWithAssociationAgainstInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\InterfaceAssociation;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Entity that references an interface.
+ *
+ * @ORM\Entity()
+ * @ORM\Table(name="entity_with_interface_association")
+ */
+class EntityWithAssociationAgainstInterface
+{
+    /**
+     * A unique ID.
+     *
+     * @var integer|null
+     * @ORM\Id
+     * @ORM\Column(type="integer", name="id")
+     * @ORM\GeneratedValue
+     */
+    public $id = null;
+
+    /**
+     * @var EntityInterface
+     * @ORM\ManyToOne(targetEntity="EntityInterface")
+     * @ORM\JoinColumn(name="entity_id", referencedColumnName="id")
+     */
+    public $entity = null;
+}


### PR DESCRIPTION
Avoids errors when working with associations against interfaces.
Allows to register a mapping from interface to concrete entity.

This is not a perfect solution and it might need some refactoring in the future, but for now it is at least usable.