### PR TITLE
Separate import and test phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ Happy testing!
 
 ## Changelog ##
 
+### 1.5.0 -> 1.5.1 ###
+
+- Clear entity manager after import to avoid problems with entities detected by cascade operations [(#23)](https://github.com/webfactory/doctrine-orm-test-infrastructure/issues/23)
+- Use separate entity managers for imports to avoid interference between import and test phase [(#2)](https://github.com/webfactory/doctrine-orm-test-infrastructure/issues/2)
+- Deprecated internal class ``\Webfactory\Doctrine\ORMTestInfrastructure\MemorizingObjectManagerDecorator`` as it is not needed anymore: there are no more selective ``detach()`` calls`after imports
+
 ### 1.4.6 -> 1.5.0 ###
 
 - Introduced ``ConnectionConfiguration`` to explicitly define the type of database connection [(#15)](https://github.com/webfactory/doctrine-orm-test-infrastructure/pull/15)

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/Importer.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/Importer.php
@@ -165,28 +165,8 @@ class Importer
             call_user_func($callback, $decorator);
             return $decorator->getSeenEntities();
         };
-        /* @var $entitiesToDetach object[]|true */
-        $entitiesToDetach = $this->entityManager->transactional($import);
-        if (is_array($entitiesToDetach)) {
-            $this->detachEntities($entitiesToDetach);
-        }
-    }
-
-    /**
-     * Detaches all provided entities.
-     *
-     * This is important for imports, as entities are not populated
-     * with database contents when they are already attached.
-     * This may lead to tests that pass because of object identity without noticing
-     * that the real reading from the database does not work as expected.
-     *
-     * @param object[] $entities
-     */
-    private function detachEntities(array $entities)
-    {
-        foreach ($entities as $entity) {
-            /* @var $entity object */
-            $this->entityManager->detach($entity);
-        }
+        $this->entityManager->transactional($import);
+        // Clear the entity manager to ensure that there are no leftovers in the identity map.
+        $this->entityManager->clear();
     }
 }

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/MemorizingObjectManagerDecorator.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/MemorizingObjectManagerDecorator.php
@@ -19,10 +19,11 @@ use Doctrine\Common\Persistence\ObjectManagerDecorator;
  * be removed from the identity map afterwards.
  *
  * @internal
+ * @deprecated Will be removed in 2.0. Not needed anymore, as selective detach()
+ *             calls have been removed from the importer.
  */
 class MemorizingObjectManagerDecorator extends ObjectManagerDecorator
 {
-
     /**
      * Contains all entities that were persisted by this object manager decorator.
      *

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
@@ -258,7 +258,12 @@ class ORMInfrastructure
     {
         $loggerWasEnabled = $this->queryLogger->enabled;
         $this->queryLogger->enabled = false;
-        $importer = new Importer($this->getEntityManager());
+        $em = EntityManager::create(
+            $this->getEntityManager()->getConnection(),
+            $this->getEntityManager()->getConfiguration(),
+            $this->entityManager->getEventManager()
+        );
+        $importer = new Importer($em);
         $importer->import($dataSource);
         $this->queryLogger->enabled = $loggerWasEnabled;
     }
@@ -324,7 +329,11 @@ class ORMInfrastructure
     {
         $config = $this->configFactory->createFor($this->entityClasses);
         $config->setSQLLogger($this->queryLogger);
-        return EntityManager::create($this->connectionConfiguration->getConnectionParameters(), $config, $this->eventManager);
+        return EntityManager::create(
+            $this->connectionConfiguration->getConnectionParameters(),
+            $config,
+            $this->eventManager
+        );
     }
 
     /**

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
@@ -258,12 +258,7 @@ class ORMInfrastructure
     {
         $loggerWasEnabled = $this->queryLogger->enabled;
         $this->queryLogger->enabled = false;
-        $em = EntityManager::create(
-            $this->getEntityManager()->getConnection(),
-            $this->getEntityManager()->getConfiguration(),
-            $this->entityManager->getEventManager()
-        );
-        $importer = new Importer($em);
+        $importer = new Importer($this->copyEntityManager());
         $importer->import($dataSource);
         $this->queryLogger->enabled = $loggerWasEnabled;
     }
@@ -426,6 +421,20 @@ class ORMInfrastructure
             }
         }
         $annotationLoaderProperty->setValue(array_values($activeLoaders));
+    }
+
+    /**
+     * Creates a copy of the current entity manager.
+     *
+     * @return EntityManager
+     */
+    private function copyEntityManager()
+    {
+        return EntityManager::create(
+            $this->getEntityManager()->getConnection(),
+            $this->getEntityManager()->getConfiguration(),
+            $this->entityManager->getEventManager()
+        );
     }
 
     /**

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/ImporterTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/ImporterTest.php
@@ -155,13 +155,12 @@ class ImporterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Checks if the importer detaches the provided entities.
+     * Checks if the importer clears the manager after import.
      */
-    public function testImporterDetachesEntities()
+    public function testImporterClearsEntityManager()
     {
-        $this->entityManager->expects($this->exactly(2))
-                            ->method('detach')
-                            ->with($this->isInstanceOf(\stdClass::class));
+        $this->entityManager->expects($this->once())
+                            ->method('clear');
 
         $entities = array(
             new \stdClass(),
@@ -181,14 +180,14 @@ class ImporterTest extends \PHPUnit_Framework_TestCase
         $this->importer->import($entities);
     }
 
-    public function testEntitiesAreDetachedAfterFlush()
+    public function testEntityManagerIsClearedAfterFlush()
     {
-        $detached = 0.0;
+        $cleared = 0.0;
         $callCounter = 0;
-        $this->entityManager->expects($this->atLeastOnce())
-            ->method('detach')
-            ->will($this->returnCallback(function () use (&$detached, &$callCounter) {
-                $detached = $callCounter++;
+        $this->entityManager->expects($this->once())
+            ->method('clear')
+            ->will($this->returnCallback(function () use (&$cleared, &$callCounter) {
+                $cleared = $callCounter++;
             }));
         $flushed = 0.0;
         $this->entityManager->expects($this->once())
@@ -202,7 +201,7 @@ class ImporterTest extends \PHPUnit_Framework_TestCase
         );
         $this->importer->import($entities);
 
-        $this->assertGreaterThan($flushed, $detached, 'detach() was called before flush().');
+        $this->assertGreaterThan($flushed, $cleared, 'clear() was called before flush().');
     }
 
     /**

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/MemorizingObjectManagerDecoratorTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/MemorizingObjectManagerDecoratorTest.php
@@ -11,6 +11,10 @@ namespace Webfactory\Doctrine\ORMTestInfrastructure;
 
 use Doctrine\Common\Persistence\ObjectManagerDecorator;
 
+/**
+ * @deprecated Will be removed in 2.0.
+ * @see \Webfactory\Doctrine\ORMTestInfrastructure\MemorizingObjectManagerDecorator
+ */
 class MemorizingObjectManagerDecoratorTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
@@ -17,6 +17,8 @@ use Webfactory\Doctrine\Config\ConnectionConfiguration;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\AnnotatedTestEntity;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Annotation\AnnotationForTestWithDependencyDiscovery;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\AnnotatedTestEntityForDependencyDiscovery;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Cascade\CascadePersistingEntity;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Cascade\CascadePersistedEntity;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\ChainReferenceEntity;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\EntityImplementation;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\InterfaceAssociation\EntityInterface;
@@ -32,7 +34,6 @@ use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntityWi
  */
 class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * System under test.
      *
@@ -525,6 +526,20 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
         // The passed configuration is simply invalid, therefore, we expect an exception.
         $this->setExpectedException('Exception');
         $this->infrastructure->getEntityManager();
+    }
+
+    /**
+     * @see https://github.com/webfactory/doctrine-orm-test-infrastructure/issues/23
+     */
+    public function testWorksWithCascadePersist()
+    {
+        $infrastructure = ORMInfrastructure::createWithDependenciesFor(CascadePersistingEntity::class);
+        $cascadingPersistingEntity = new CascadePersistingEntity();
+        $cascadingPersistingEntity->add(new CascadePersistedEntity());
+        $infrastructure->import($cascadingPersistingEntity);
+
+        $this->setExpectedException(null);
+        $infrastructure->getEntityManager()->flush();
     }
 
     /**

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructureTest.php
@@ -539,6 +539,7 @@ class ORMInfrastructureTest extends \PHPUnit_Framework_TestCase
         $infrastructure->import($cascadingPersistingEntity);
 
         $this->setExpectedException(null);
+        // If this call fails, then there are leftovers in the identity map.
         $infrastructure->getEntityManager()->flush();
     }
 

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/Cascade/CascadePersistedEntity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/Cascade/CascadePersistedEntity.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * (c) webfactory GmbH <info@webfactory.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Cascade;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Entity that automatically persists its associated entities.
+ *
+ * @ORM\Entity()
+ * @ORM\Table(name="cascade_persisted_entity")
+ */
+class CascadePersistedEntity
+{
+    /**
+     * A unique ID.
+     *
+     * @var integer|null
+     * @ORM\Id
+     * @ORM\Column(type="integer", name="id")
+     * @ORM\GeneratedValue
+     */
+    public $id = null;
+
+    /**
+     * @var CascadePersistingEntity
+     * @ORM\ManyToOne(targetEntity="CascadePersistingEntity")
+     */
+    public $parent;
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/Cascade/CascadePersistingEntity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/Cascade/CascadePersistingEntity.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * (c) webfactory GmbH <info@webfactory.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\Cascade;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Entity that automatically persists its associated entities.
+ *
+ * @ORM\Entity()
+ * @ORM\Table(name="cascade_persist")
+ */
+class CascadePersistingEntity
+{
+    /**
+     * A unique ID.
+     *
+     * @var integer|null
+     * @ORM\Id
+     * @ORM\Column(type="integer", name="id")
+     * @ORM\GeneratedValue
+     */
+    public $id = null;
+
+    /**
+     * @var Collection
+     * @ORM\OneToMany(targetEntity="CascadePersistedEntity", mappedBy="parent", cascade={"persist"})
+     */
+    private $associated;
+
+    /**
+     * Initializes the collection.
+     */
+    public function __construct()
+    {
+        $this->associated = new ArrayCollection();
+    }
+
+    /**
+     * Adds the given entity to the persisting association.
+     *
+     * @param CascadePersistedEntity $entity
+     */
+    public function add(CascadePersistedEntity $entity)
+    {
+        $entity->parent = $this;
+        $this->associated->add($entity);
+    }
+}


### PR DESCRIPTION
Introduces separate entity managers for imports to decouple import and test phase. This avoids problems with dynamically detected entities like documented in (#23). (fixes #23, fixes #2)

@MalteWunsch Please check if this change solves your problem. Then merge and tag as ``1.5.1`` (suggestion).