### PR TITLE
Make it possible to provide/pass in the DBAL connection

### DIFF
--- a/src/Webfactory/Doctrine/Config/ExistingConnectionConfiguration.php
+++ b/src/Webfactory/Doctrine/Config/ExistingConnectionConfiguration.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Webfactory\Doctrine\Config;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Allows to use a pre-existing Doctrine DBAL connection with the ORMInfrastructure
+ */
+class ExistingConnectionConfiguration extends ConnectionConfiguration
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @param Connection $connection
+     */
+    public function __construct(Connection $connection)
+    {
+        parent::__construct([]);
+
+        $this->connection = $connection;
+    }
+
+    /**
+     * Provides the existing DBAL connection
+     *
+     * This makes use of the fact that the first argument to EntityManager::create() is in fact
+     * un-typed: You can pass in either a configuration array or an existing DBAL connection.
+     *
+     * @return Connection
+     */
+    public function getConnectionParameters()
+    {
+        return $this->connection;
+    }
+}

--- a/tests/Webfactory/Doctrine/Config/ExistingConnectionConfigurationTest.php
+++ b/tests/Webfactory/Doctrine/Config/ExistingConnectionConfigurationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Webfactory\Doctrine\Config;
+
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity;
+
+class ExistingConnectionConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ExistingConnectionConfiguration
+     */
+    private $connectionConfiguration = null;
+
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * Initializes the test environment.
+     */
+    protected function setUp()
+    {
+        $this->connection = DriverManager::getConnection([
+            'driver' => 'pdo_sqlite',
+            'memory' => true,
+        ]);
+
+        $this->connectionConfiguration = new ExistingConnectionConfiguration($this->connection);
+
+        parent::setUp();
+    }
+
+    public function testWorksWithInfrastructure()
+    {
+        $infrastructure = ORMInfrastructure::createOnlyFor(
+            ['Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntity'],
+            $this->connectionConfiguration
+        );
+
+        $infrastructure->import(new TestEntity());
+
+        $this->assertEquals(1, $this->connection->fetchColumn('SELECT COUNT(*) FROM test_entity'));
+    }
+
+}


### PR DESCRIPTION
It's very simple to use the `ORMInfrastructure` when unit testing your Doctrine ORM repositories, as it takes care of setting up the database schema and provides a simple way to import a bunch of entities.

Wouldn't it be useful if we had (almost) the same tooling when writing functional tests?

One way to make this work (at least with functional tests for Symfony applications) is to use an on-disk SQLite database: Use the same database/file in the `ORMInfrastructure` setup and your application (e. g. the Symfony application `config_test.yaml`).

The other approach is to make both `ORMInfrastructure` and the application share the same DBAL `Connection` to an in-memory database: This is what this PR is about.

