### PR TITLE
With `ORMInfrastructure::createWithDependenciesFor()`, only consider creating really necessary tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-/vendor/
-phpunit.xml
-composer.phar
-/.idea/
-build/
-cache.properties
+/vendor
+phpunit.xml$
+.phpunit.result.cache
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,9 @@
         }
     },
     "autoload-dev": {
+        "psr-0": {
+            "Webfactory\\Doctrine": "tests/"
+        },
         "classmap": [
             "tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/"
         ]

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/ORMInfrastructure.php
@@ -299,7 +299,7 @@ class ORMInfrastructure
             $this->entityManager = $this->createEntityManager();
             $this->setupResolveTargetListener();
             if ($this->createSchema) {
-                $this->createSchemaForSupportedEntities($this->entityManager);
+                $this->createSchemaForSupportedEntities();
             }
             $this->queryLogger->enabled = $loggerWasEnabled;
         }
@@ -360,24 +360,22 @@ class ORMInfrastructure
 
     /**
      * Creates the schema for the managed entities.
-     *
-     * @param EntityManager $entityManager
      */
-    protected function createSchemaForSupportedEntities(EntityManager $entityManager)
+    protected function createSchemaForSupportedEntities()
     {
-        $metadata   = $this->getMetadataForSupportedEntities($entityManager->getMetadataFactory());
-        $schemaTool = new SchemaTool($entityManager);
+        $metadata   = $this->getMetadataForSupportedEntities();
+        $schemaTool = new SchemaTool($this->entityManager);
         $schemaTool->createSchema($metadata);
     }
 
     /**
      * Returns the metadata for each managed entity.
      *
-     * @param ClassMetadataFactory $metadataFactory
      * @return \Doctrine\Common\Persistence\Mapping\ClassMetadata[]
      */
-    protected function getMetadataForSupportedEntities(ClassMetadataFactory $metadataFactory)
+    public function getMetadataForSupportedEntities()
     {
+        $metadataFactory = $this->getEntityManager()->getMetadataFactory();
         $metadata = array();
         foreach ($this->entityClasses as $class) {
             $metadata[] = $metadataFactory->getMetadataFor($class);

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/EntityDependencyResolverTest.php
@@ -175,21 +175,6 @@ class EntityDependencyResolverTest extends TestCase
     }
 
     /**
-     * Ensures that a mapped super class is listed in the resolved set.
-     */
-    public function testResolvedSetContainsNameOfMappedSuperClass()
-    {
-        $resolver = new EntityDependencyResolver(array(
-            MappedSuperClassChild::class
-        ));
-
-        $this->assertContainsEntity(
-            MappedSuperClassParentWithReference::class,
-            $resolver
-        );
-    }
-
-    /**
      * Ensures that an entity, that is referenced by a mapped super class, is listed in the resolved set.
      */
     public function testResolvedSetContainsNameOfEntityThatIsReferencedByMappedSuperClass()

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/DependencyResolverFixtures/JoinedTableInheritance/Entity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/DependencyResolverFixtures/JoinedTableInheritance/Entity.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\_files\ORMInfrastructure\Entity\DependencyResolverFixtures\JoinedTableInheritance;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorColumn(name="class", type="string")
+ * @ORM\DiscriminatorMap({"base" = "BaseEntity",  "sub" = "Entity"})
+ */
+class BaseEntity
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     */
+    private $id;
+
+    /**
+     * @ORM\Column
+     */
+    protected $fieldA;
+}
+
+/**
+ * @ORM\Entity()
+ */
+class Entity extends BaseEntity
+{
+    /**
+     * @ORM\Column
+     */
+    protected $fieldB;
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/DependencyResolverFixtures/JoinedTableInheritanceWithTwoLevels/Entity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/DependencyResolverFixtures/JoinedTableInheritanceWithTwoLevels/Entity.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\_files\ORMInfrastructure\Entity\DependencyResolverFixtures\JoinedTableInheritanceWithTwoLevels;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorColumn(name="class", type="string")
+ * @ORM\DiscriminatorMap({"base" = "BaseEntity",  "intermediate" = "IntermediateEntity", "child" = "Entity"})
+ */
+class BaseEntity
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     */
+    private $id;
+
+    /**
+     * @ORM\Column
+     */
+    protected $fieldA;
+}
+
+/**
+ * @ORM\Entity()
+ */
+class IntermediateEntity extends BaseEntity
+{
+    /**
+     * @ORM\Column
+     */
+    protected $fieldB;
+}
+
+/**
+ * @ORM\Entity()
+ */
+class Entity extends IntermediateEntity
+{
+    /**
+     * @ORM\Column
+     */
+    protected $fieldC;
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/DependencyResolverFixtures/JoinedTableInheritanceWithTwoSubclasses/Entity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/DependencyResolverFixtures/JoinedTableInheritanceWithTwoSubclasses/Entity.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\_files\ORMInfrastructure\Entity\DependencyResolverFixtures\JoinedTableInheritanceWithTwoSubclasses;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorColumn(name="class", type="string")
+ * @ORM\DiscriminatorMap({"base" = "BaseEntity",  "first" = "Entity", "second" = "SecondEntity"})
+ */
+class BaseEntity
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     */
+    private $id;
+
+    /**
+     * @ORM\Column
+     */
+    protected $fieldA;
+}
+
+/**
+ * @ORM\Entity()
+ */
+class SecondEntity extends BaseEntity
+{
+    /**
+     * @ORM\Column
+     */
+    protected $fieldB;
+}
+
+/**
+ * @ORM\Entity()
+ */
+class Entity extends BaseEntity
+{
+    /**
+     * @ORM\Column
+     */
+    protected $fieldC;
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/DependencyResolverFixtures/MappedSuperclassInheritance/Entity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/DependencyResolverFixtures/MappedSuperclassInheritance/Entity.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\_files\ORMInfrastructure\Entity\DependencyResolverFixtures\MappedSuperclassInheritance;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\MappedSuperclass()
+ */
+class Superclass
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     */
+    private $id;
+
+    /**
+     * @ORM\Column
+     */
+    protected $fieldA;
+}
+
+/**
+ * @ORM\Entity()
+ */
+class Entity extends Superclass
+{
+    /**
+     * @ORM\Column
+     */
+    protected $fieldB;
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/DependencyResolverFixtures/SingleEntity/Entity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/DependencyResolverFixtures/SingleEntity/Entity.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\_files\ORMInfrastructure\Entity\DependencyResolverFixtures\SingleEntity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Entity
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     */
+    private $id;
+
+    /**
+     * @ORM\Column
+     */
+    protected $fieldA;
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/DependencyResolverFixtures/SingleTableInheritance/Entity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/DependencyResolverFixtures/SingleTableInheritance/Entity.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\_files\ORMInfrastructure\Entity\DependencyResolverFixtures\SingleTableInheritance;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorColumn(name="class", type="string")
+ * @ORM\DiscriminatorMap({"base" = "BaseEntity",  "sub" = "Entity"})
+ */
+class BaseEntity
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     */
+    private $id;
+
+    /**
+     * @ORM\Column
+     */
+    protected $fieldA;
+}
+
+/**
+ * @ORM\Entity()
+ */
+class Entity extends BaseEntity
+{
+    /**
+     * @ORM\Column
+     */
+    protected $fieldB;
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/DependencyResolverFixtures/TransientBaseClass/Entity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/DependencyResolverFixtures/TransientBaseClass/Entity.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\_files\ORMInfrastructure\Entity\DependencyResolverFixtures\TransientBaseClass;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class BaseClass
+{
+    /**
+     * @ORM\Column
+     */
+    protected $fieldA;
+}
+
+/**
+ * @ORM\Entity()
+ */
+class Entity extends BaseClass
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     */
+    private $id;
+
+    /**
+     * @ORM\Column
+     */
+    protected $fieldB;
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/DependencyResolverFixtures/TwoEntitiesInheritance/Entity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/DependencyResolverFixtures/TwoEntitiesInheritance/Entity.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\_files\ORMInfrastructure\Entity\DependencyResolverFixtures\TwoEntitiesInheritance;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Superclass
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     */
+    private $id;
+
+    /**
+     * @ORM\Column
+     */
+    protected $fieldA;
+}
+
+/**
+ * @ORM\Entity()
+ */
+class Entity extends Superclass
+{
+    /**
+     * @ORM\Column
+     */
+    protected $fieldB;
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/DependencyResolverFixtures/TwoEntitiesInheritanceWithConflictingTableNames/Entity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/DependencyResolverFixtures/TwoEntitiesInheritanceWithConflictingTableNames/Entity.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\_files\ORMInfrastructure\Entity\DependencyResolverFixtures\TwoEntitiesInheritanceWithConflictingTableNames;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="some_table")
+ */
+class Superclass
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     */
+    private $id;
+
+    /**
+     * @ORM\Column
+     */
+    protected $fieldA;
+}
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="some_table")
+ */
+class Entity extends Superclass
+{
+    /**
+     * @ORM\Column
+     */
+    protected $fieldB;
+}


### PR DESCRIPTION
When using `ORMInfrastructure::createWithDependenciesFor()`, the `EntityDependencyResolver` class would try to find all classes related to the given base set and also create (temporary) tables for them.

That comes in handy when you have a "snowflake"-like schema where a "core" class has associations to a few supporting/surrounding classes.

Until now, the `EntityDependencyResolver` would also go up in inheritance relationships and would attempt to create tables for parent classes as well. With this PR, behavior is changed to only create such tables when they are necessary because of single or joined table inheritance.

Why is that helpful?

Assume you're extending from a base class that comes from another package/author. That class may have `@ORM\Entity` and related annotations, but you chose to setup the Doctrine Mapping in a way that classes from this other package are ignored.

Now when you _extend_ such a class, the `EntityDependencyResolver` would include the class in the mapping. Depending on circumstances, you might for example end up with duplicate table errors when both classes use the same "local" name and do not provide a `table` parameter in the `@Entity` mapping.

Since there is no need to include parent classes unless they are part of a Doctrine Inheritance Type Mapping, this will prevent the error.
