### PR TITLE
Add support for all mapping drivers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,13 @@
     "require": {
         "php": "^7.2|8.0.*|8.1.*",
         "doctrine/annotations": "^1.8",
-        "doctrine/cache": "^1.9.1",
+        "doctrine/cache": "^1.9.1|^2.0",
         "doctrine/common": "^2.11|^3.0",
         "doctrine/dbal": "^2.12|^3.0",
         "doctrine/event-manager": "^1.1",
         "doctrine/orm": "^2.7",
-        "doctrine/persistence": "^1.3|^2.0"
+        "doctrine/persistence": "^1.3|^2.0",
+        "symfony/cache": "4.4|^5.4|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.0"

--- a/src/Webfactory/Doctrine/ORMTestInfrastructure/Importer.php
+++ b/src/Webfactory/Doctrine/ORMTestInfrastructure/Importer.php
@@ -160,12 +160,7 @@ class Importer
      */
     protected function importFromCallback($callback)
     {
-        $import = function (ObjectManager $objectManager) use ($callback) {
-            $decorator = new MemorizingObjectManagerDecorator($objectManager);
-            call_user_func($callback, $decorator);
-            return $decorator->getSeenEntities();
-        };
-        $this->entityManager->transactional($import);
+        $this->entityManager->transactional($callback);
         // Clear the entity manager to ensure that there are no leftovers in the identity map.
         $this->entityManager->clear();
     }

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Attribute/AttributeForSimpleTest.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Attribute/AttributeForSimpleTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\_files\ORMInfrastructure\Attribute;
+
+use Attribute;
+
+if (PHP_VERSION_ID >= 80000) {
+    #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
+    class AttributeForSimpleTest
+    {
+
+    }
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/AttributedTestEntity.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/AttributedTestEntity.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * (c) webfactory GmbH <info@webfactory.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest;
+
+use Doctrine\ORM\Mapping as ORM;
+use Webfactory\Doctrine\ORMTestInfrastructure\_files\ORMInfrastructure\Attribute\AttributeForSimpleTest;
+
+if (PHP_VERSION_ID >= 80000) {
+    /**
+     * An entity that uses a custom attribute.
+     */
+    #[ORM\Entity]
+    #[ORM\Table(name: 'attributed_test_entity')]
+    #[AttributeForSimpleTest]
+    class AttributedTestEntity
+    {
+        /**
+         * A unique ID.
+         *
+         * @var integer|null
+         */
+        #[ORM\Id]
+        #[ORM\Column(type: 'integer', name: 'id')]
+        #[ORM\GeneratedValue]
+        public $id = null;
+    }
+
+}

--- a/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/TestEntityWithAttribute.php
+++ b/tests/Webfactory/Doctrine/ORMTestInfrastructure/_files/ORMInfrastructure/Entity/TestEntityWithAttribute.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure\_files\ORMInfrastructure\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructureTest\TestEntityRepository;
+
+if (PHP_VERSION_ID >= 80000) {
+
+    /**
+     * Doctrine entity that is used for testing.
+     */
+    #[ORM\Entity(repositoryClass: TestEntityRepository::class)]
+    #[ORM\Table(name: 'test_entity')]
+    class TestEntityWithAttribute
+    {
+        /**
+         * A unique ID.
+         *
+         * @var integer|null
+         */
+         #[ORM\Id]
+         #[ORM\Column(type: 'integer', name: 'id')]
+         #[ORM\GeneratedValue]
+        public $id = null;
+
+        /**
+         * A string property.
+         *
+         * @var string|null
+         */
+         #[ORM\Column(type: 'string', name: 'name', nullable: true)]
+        public $name = null;
+    }
+}


### PR DESCRIPTION
With PHP8 Attributes, Doctrine is slowly phasing out annotations. It would be awesome to have support for Attributes with this project, as well as other Mapping Driver.

It would probably also fix #14.