### PR TITLE
Use the ORMSetup class added in doctrine/orm ^2.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
+        "cache/array-adapter": "^1.0",
         "doctrine/annotations": "^1.8|^2.0",
-        "doctrine/cache": "^1.9.1",
         "doctrine/common": "^2.11|^3.0",
         "doctrine/dbal": "^2.12|^3.0",
         "doctrine/event-manager": "^1.1|^2.0",
-        "doctrine/orm": "^2.7",
+        "doctrine/orm": "^2.12",
         "doctrine/persistence": "^1.3|^2.0|^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
... instead of the old, deprecated `Doctrine\ORM\Tools\Setup` class. Also, use a more lightweight array cache implementation instead of the full doctrine/cache dependency.
