### PR TITLE
Allow passing the mapping driver to `ORMInfrastructure::create*()` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,59 +42,7 @@ class MyEntityRepositoryTest extends TestCase
            for the MyEntity entity class and and everything reachable from it through
            associations.
         */
-        $this->infrastructure = <?php
-        
-        use Doctrine\ORM\EntityManagerInterface;
-        use Entity\MyEntity;
-        use Entity\MyEntityRepository;
-        use PHPUnit\Framework\TestCase;
-        use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure;
-        
-        class MyEntityRepositoryTest extends TestCase
-        {
-            private ORMInfrastructure $infrastructure;
-            private MyEntityRepository $repository;
-        
-            protected function setUp(): void
-            {
-                $this->infrastructure = ORMInfrastructure::createWithDependenciesFor(MyEntity::class);
-                $this->repository = $this->infrastructure->getRepository(MyEntity::class);
-            }
-        
-            /**
-             * Example test: Asserts imported fixtures are retrieved with findAll().
-             */
-            public function testFindAllRetrievesFixtures(): void
-            {
-                $myEntityFixture = new MyEntity();
-
-                $this->infrastructure->import($myEntityFixture);
-                $entitiesLoadedFromDatabase = $this->repository->findAll();
-
-                /*
-                    import() will use a dedicated entity manager, so imported entities do not
-                    end up in the identity map. But this also means loading entities from the
-                    database will create _different object instances_.
-
-                    So, this does not hold:
-                */
-                // $this->assertContains($myEntityFixture, $entitiesLoadedFromDatabase);
-
-                // But you can do things like this (you probably want to extract that in a convenient assertion method):
-                $this->assertCount(1, $entitiesLoadedFromDatabase);
-                $entityLoadedFromDatabase = $entitiesLoadedFromDatabase[0];
-                $this->assertEquals($myEntityFixture->getId(), $entityLoadedFromDatabase->getId());
-            }
-
-            /**
-             * Example test for retrieving Doctrine's entity manager.
-             */
-            public function testSomeFancyThingWithEntityManager(): void
-            {
-                $entityManager = $this->infrastructure->getEntityManager();
-                // ...
-            }
-        }
+        $this->infrastructure = ORMInfrastructure::createWithDependenciesFor(MyEntity::class);
         $this->repository = $this->infrastructure->getRepository(MyEntity::class);
     }
 
@@ -104,8 +52,8 @@ class MyEntityRepositoryTest extends TestCase
     public function testFindAllRetrievesFixtures(): void
     {
         $myEntityFixture = new MyEntity();
-        $this->infrastructure->import($myEntityFixture);
 
+        $this->infrastructure->import($myEntityFixture);
         $entitiesLoadedFromDatabase = $this->repository->findAll();
 
         /* 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ heavyweight [functional tests suggested in the Symfony documentation](http://sym
 In non-application bundles, where functional tests are not possible,
 it is our only way to test repositories and entities.
 
+Installation
+------------
+
+Install via composer (see http://getcomposer.org/):
+
+    composer require --dev webfactory/doctrine-orm-test-infrastructure
+
 Usage
 -----
 

--- a/README.md
+++ b/README.md
@@ -6,79 +6,150 @@ doctrine-orm-test-infrastructure
 This library provides some infrastructure for tests of Doctrine ORM entities, featuring:
 
 - configuration of a SQLite in memory database, compromising well between speed and a database environment being both
-  realistic and isolated 
+  realistic and isolated
 - a mechanism for importing fixtures into your database that circumvents Doctrine's caching. This results in a more
   realistic test environment when loading entities from a repository.
 
 [We](https://www.webfactory.de/) use it to test Doctrine repositories and entities in Symfony applications. It's a
-lightweight alternative to the heavyweight [functional tests suggested in the Symfony documentation](http://symfony.com/doc/current/cookbook/testing/doctrine.html)
-(we don't suggest you should skip those - we just want to open another path). 
+lightweight alternative to the
+heavyweight [functional tests suggested in the Symfony documentation](http://symfony.com/doc/current/cookbook/testing/doctrine.html)
+(we don't suggest you should skip those - we just want to open another path).
 
 In non-application bundles, where functional tests are not possible,
 it is our only way to test repositories and entities.
 
-
-Installation
-------------
-
-Install via composer (see http://getcomposer.org/):
-
-    composer require --dev webfactory/doctrine-orm-test-infrastructure
-
-
 Usage
 -----
 
-    <?php
-    
-    use Entity\MyEntity;
-    use Entity\MyEntityRepository;
-    use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure;
-    
-    class MyEntityRepositoryTest extends \PHPUnit_Framework_TestCase
+```php
+<?php
+
+use Doctrine\ORM\EntityManagerInterface;
+use Entity\MyEntity;
+use Entity\MyEntityRepository;
+use PHPUnit\Framework\TestCase;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure;
+
+class MyEntityRepositoryTest extends TestCase
+{
+    private ORMInfrastructure $infrastructure;
+    private MyEntityRepository $repository;
+
+    protected function setUp(): void
     {
-        /** @var ORMInfrastructure */
-        private $infrastructure;
+        /*
+           This will create an in-memory SQLite database with the necessary schema
+           for the MyEntity entity class and and everything reachable from it through
+           associations.
+        */
+        $this->infrastructure = <?php
         
-        /** @var MyEntityRepository */
-        private $repository;
+        use Doctrine\ORM\EntityManagerInterface;
+        use Entity\MyEntity;
+        use Entity\MyEntityRepository;
+        use PHPUnit\Framework\TestCase;
+        use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure;
         
-        /** @see \PHPUnit_Framework_TestCase::setUp() */
-        protected function setUp()
+        class MyEntityRepositoryTest extends TestCase
         {
-            $this->infrastructure = ORMInfrastructure::createWithDependenciesFor(MyEntity::class);
-            $this->repository = $this->infrastructure->getRepository(MyEntity::class);
-        }
+            private ORMInfrastructure $infrastructure;
+            private MyEntityRepository $repository;
         
-        /**
-         * Example test: Asserts imported fixtures are retrieved with findAll().
-         */
-        public function testFindAllRetrievesFixtures()
-        {
-            $myEntityFixture = new MyEntity();
-            $this->infrastructure->import($myEntityFixture);
-            
-            $entitiesLoadedFromDatabase = $this->repository->findAll();
+            protected function setUp(): void
+            {
+                $this->infrastructure = ORMInfrastructure::createWithDependenciesFor(MyEntity::class);
+                $this->repository = $this->infrastructure->getRepository(MyEntity::class);
+            }
+        
+            /**
+             * Example test: Asserts imported fixtures are retrieved with findAll().
+             */
+            public function testFindAllRetrievesFixtures(): void
+            {
+                $myEntityFixture = new MyEntity();
 
-            // Please note that you cannot do the following:
-            // $this->assertContains($myEntityFixture, $entitiesLoadedFromDatabase);
+                $this->infrastructure->import($myEntityFixture);
+                $entitiesLoadedFromDatabase = $this->repository->findAll();
 
-            // But you can do things like this (you probably want to extract that in a convenient assertion method):
-            $this->assertCount(1, $entitiesLoadedFromDatabase);
-            $entityLoadedFromDatabase = $entitiesLoadedFromDatabase[0];
-            $this->assertEquals($myEntityFixture->getId(), $entityLoadedFromDatabase->getId());
+                /*
+                    import() will use a dedicated entity manager, so imported entities do not
+                    end up in the identity map. But this also means loading entities from the
+                    database will create _different object instances_.
+
+                    So, this does not hold:
+                */
+                // $this->assertContains($myEntityFixture, $entitiesLoadedFromDatabase);
+
+                // But you can do things like this (you probably want to extract that in a convenient assertion method):
+                $this->assertCount(1, $entitiesLoadedFromDatabase);
+                $entityLoadedFromDatabase = $entitiesLoadedFromDatabase[0];
+                $this->assertEquals($myEntityFixture->getId(), $entityLoadedFromDatabase->getId());
+            }
+
+            /**
+             * Example test for retrieving Doctrine's entity manager.
+             */
+            public function testSomeFancyThingWithEntityManager(): void
+            {
+                $entityManager = $this->infrastructure->getEntityManager();
+                // ...
+            }
         }
-        
-        /**
-         * Example test for retrieving Doctrine's entity manager.
-         */
-        public function testSomeFancyThingWithEntityManager()
-        {
-            $entityManager = $this->infrastructure->getEntityManager();
-            // ...
-        }
+        $this->repository = $this->infrastructure->getRepository(MyEntity::class);
     }
-    
+
+    /**
+     * Example test: Asserts imported fixtures are retrieved with findAll().
+     */
+    public function testFindAllRetrievesFixtures(): void
+    {
+        $myEntityFixture = new MyEntity();
+        $this->infrastructure->import($myEntityFixture);
+
+        $entitiesLoadedFromDatabase = $this->repository->findAll();
+
+        /* 
+            import() will use a dedicated entity manager, so imported entities do not
+            end up in the identity map. But this also means loading entities from the
+            database will create _different object instances_.
+
+            So, this does not hold:
+        */
+        // self::assertContains($myEntityFixture, $entitiesLoadedFromDatabase);
+
+        // But you can do things like this (you probably want to extract that in a convenient assertion method):
+        self::assertCount(1, $entitiesLoadedFromDatabase);
+        $entityLoadedFromDatabase = $entitiesLoadedFromDatabase[0];
+        self::assertSame($myEntityFixture->getId(), $entityLoadedFromDatabase->getId());
+    }
+
+    /**
+     * Example test for retrieving Doctrine's entity manager.
+     */
+    public function testSomeFancyThingWithEntityManager(): void
+    {
+        $entityManager = $this->infrastructure->getEntityManager();
+        // ...
+    }
+}
+```
+
+Migrating to attribute-based mapping configuration
+--------------------------------------------------
+
+The `ORMInfrastructure::createWithDependenciesFor()` and ``ORMInfrastructure::createOnlyFor()` methods by default
+assume that the Doctrine ORM mapping is provided through annotations. This has been deprecated in Doctrine ORM 2.x
+and is no longer be supported in ORM 3.0.
+
+To allow for a seamless transition towards attribute-based or other types of mapping, a mapping driver can be passed
+when creating instances of the `ORMInfrastructure`.
+
+If you wish to switch to attribute-based mappings, pass a `new \Doctrine\ORM\Mapping\Driver\AttributeDriver($paths)`,
+where `$paths` is an array of directory paths where your entity classes are stored.
+
+For hybrid (annotations and attributes) mapping configurations, you can use `\Doctrine\Persistence\Mapping\Driver\MappingDriverChain`.
+Multiple mapping drivers can be registered on the driver chain by providing namespace prefixes. For every namespace prefix,
+only one mapping driver can be used.
 
 Testing the library itself
 --------------------------
@@ -92,20 +163,23 @@ need local changes.
 
 Happy testing!
 
-
 ## Changelog ##
 
 ### 1.5.0 -> 1.5.1 ###
 
-- Clear entity manager after import to avoid problems with entities detected by cascade operations [(#23)](https://github.com/webfactory/doctrine-orm-test-infrastructure/issues/23)
-- Use separate entity managers for imports to avoid interference between import and test phase [(#2)](https://github.com/webfactory/doctrine-orm-test-infrastructure/issues/2)
-- Deprecated internal class ``\Webfactory\Doctrine\ORMTestInfrastructure\MemorizingObjectManagerDecorator`` as it is not needed anymore: there are no more selective ``detach()`` calls`after imports
+- Clear entity manager after import to avoid problems with entities detected by cascade
+  operations [(#23)](https://github.com/webfactory/doctrine-orm-test-infrastructure/issues/23)
+- Use separate entity managers for imports to avoid interference between import and test
+  phase [(#2)](https://github.com/webfactory/doctrine-orm-test-infrastructure/issues/2)
+- Deprecated internal class ``\Webfactory\Doctrine\ORMTestInfrastructure\MemorizingObjectManagerDecorator`` as it is not needed anymore: there are no
+  more selective ``detach()`` calls`after imports
 
 ### 1.4.6 -> 1.5.0 ###
 
-- Introduced ``ConnectionConfiguration`` to explicitly define the type of database connection [(#15)](https://github.com/webfactory/doctrine-orm-test-infrastructure/pull/15)
-- Added support for simple SQLite file databases via ``FileDatabaseConnectionConfiguration``; useful when data must persist for some time, but the connection is reset, e.g. in Symfony's [Functional Tests](http://symfony.com/doc/current/testing.html#functional-tests)
-
+- Introduced ``ConnectionConfiguration`` to explicitly define the type of database
+  connection [(#15)](https://github.com/webfactory/doctrine-orm-test-infrastructure/pull/15)
+- Added support for simple SQLite file databases via ``FileDatabaseConnectionConfiguration``; useful when data must persist for some time, but the
+  connection is reset, e.g. in Symfony's [Functional Tests](http://symfony.com/doc/current/testing.html#functional-tests)
 
 Create file-backed database:
 
@@ -122,7 +196,6 @@ Create file-backed database:
 - Ignore associations against interfaces when detecting dependencies via ``ORMInfrastructure::createWithDependenciesFor`` to avoid errors
 - Exposed event manager and created helper method to be able to register entity mappings
 
-
 Register entity type mapping:
 
     $infrastructure->registerEntityMapping(EntityInterface::class, EntityImplementation::class);
@@ -131,7 +204,8 @@ Do not rely on this "feature" if you don't have to. Might be restructured in fut
 
 ### 1.4.4 -> 1.4.5 ###
 
-- Fixed bug [#20](https://github.com/webfactory/doctrine-orm-test-infrastructure/issues/20): Entities might have been imported twice in case of bidirectional cascade
+- Fixed bug [#20](https://github.com/webfactory/doctrine-orm-test-infrastructure/issues/20): Entities might have been imported twice in case of
+  bidirectional cascade
 - Deprecated class ``Webfactory\Doctrine\ORMTestInfrastructure\DetachingObjectManagerDecorator`` (will be removed in next major release)
 
 ### 1.4.3 -> 1.4.4 ###
@@ -140,12 +214,12 @@ Do not rely on this "feature" if you don't have to. Might be restructured in fut
 - Dropped support for PHP < 5.5
 - Officially support PHP 7
 
-
 Known Issues
 ------------
 
 Please note that apart from any [open issues in this library](https://github.com/webfactory/doctrine-orm-test-infrastructure/issues), you
-may stumble upon any Doctrine issues. Especially take care of it's [known sqlite issues](http://doctrine-dbal.readthedocs.org/en/latest/reference/known-vendor-issues.html#sqlite).
+may stumble upon any Doctrine issues. Especially take care of
+it's [known sqlite issues](http://doctrine-dbal.readthedocs.org/en/latest/reference/known-vendor-issues.html#sqlite).
 
 Credits, Copyright and License
 ------------------------------
@@ -154,9 +228,8 @@ This package was first written by webfactory GmbH (Bonn, Germany) and received [
 from other people](https://github.com/webfactory/doctrine-orm-test-infrastructure/graphs/contributors) since then.
 
 webfactory is a software development agency with a focus on PHP (mostly [Symfony](http://github.com/symfony/symfony)).
-If you're a developer looking for new challenges, we'd like to hear from you! 
+If you're a developer looking for new challenges, we'd like to hear from you!
 
 - <https://www.webfactory.de>
-- <https://twitter.com/webfactory>
 
-Copyright 2012 – 2020 webfactory GmbH, Bonn. Code released under [the MIT license](LICENSE).
+Copyright 2012 – 2024 webfactory GmbH, Bonn. Code released under [the MIT license](LICENSE).

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "cache/array-adapter": "^1.0",
         "doctrine/annotations": "^1.8|^2.0",
         "doctrine/common": "^2.11|^3.0",
         "doctrine/dbal": "^2.12|^3.0",
         "doctrine/event-manager": "^1.1|^2.0",
         "doctrine/orm": "^2.12",
-        "doctrine/persistence": "^1.3|^2.0|^3.0"
+        "doctrine/persistence": "^1.3|^2.0|^3.0",
+        "symfony/cache": "^4.0|^5.0|^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.36|^9.6.17"

--- a/src/ORMTestInfrastructure/ConfigurationFactory.php
+++ b/src/ORMTestInfrastructure/ConfigurationFactory.php
@@ -9,7 +9,6 @@
 
 namespace Webfactory\Doctrine\ORMTestInfrastructure;
 
-use Cache\Adapter\PHPArray\ArrayCachePool;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
@@ -17,6 +16,7 @@ use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\ORMSetup;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * Creates ORM configurations for a set of entities.
@@ -55,12 +55,12 @@ class ConfigurationFactory
     public function createFor(array $entityClasses)
     {
         if (self::$metadataCache === null) {
-            self::$metadataCache = new ArrayCachePool();
+            self::$metadataCache = new ArrayAdapter();
         }
 
         $mappingDriver = $this->mappingDriver ?? $this->createDefaultAnnotationsDriver($entityClasses);
 
-        $config = ORMSetup::createConfiguration(true, null, new ArrayCachePool());
+        $config = ORMSetup::createConfiguration(true, null, new ArrayAdapter());
         $config->setMetadataCache(self::$metadataCache);
         $config->setMetadataDriverImpl(new EntityListDriverDecorator($mappingDriver, $entityClasses));
 
@@ -114,7 +114,7 @@ class ConfigurationFactory
     protected function getAnnotationReader()
     {
         if (static::$defaultAnnotationReader === null) {
-            static::$defaultAnnotationReader = new PsrCachedReader(new AnnotationReader(), new ArrayCachePool());
+            static::$defaultAnnotationReader = new PsrCachedReader(new AnnotationReader(), new ArrayAdapter());
         }
 
         return static::$defaultAnnotationReader;

--- a/src/ORMTestInfrastructure/EntityDependencyResolver.php
+++ b/src/ORMTestInfrastructure/EntityDependencyResolver.php
@@ -9,6 +9,7 @@
 
 namespace Webfactory\Doctrine\ORMTestInfrastructure;
 
+use Cassandra\Map;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
@@ -49,11 +50,11 @@ class EntityDependencyResolver implements \IteratorAggregate
      *
      * @param string[] $entityClasses
      */
-    public function __construct(array $entityClasses)
+    public function __construct(array $entityClasses, MappingDriver $mappingDriver = null)
     {
         $this->initialEntitySet  = $this->normalizeClassNames($entityClasses);
         $this->reflectionService = new RuntimeReflectionService();
-        $this->configFactory     = new ConfigurationFactory();
+        $this->configFactory     = new ConfigurationFactory($mappingDriver);
     }
 
     /**

--- a/src/ORMTestInfrastructure/EntityDependencyResolver.php
+++ b/src/ORMTestInfrastructure/EntityDependencyResolver.php
@@ -9,7 +9,6 @@
 
 namespace Webfactory\Doctrine\ORMTestInfrastructure;
 
-use Cassandra\Map;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;

--- a/src/ORMTestInfrastructure/ORMInfrastructure.php
+++ b/src/ORMTestInfrastructure/ORMInfrastructure.php
@@ -167,11 +167,7 @@ class ORMInfrastructure
      * @param ConnectionConfiguration|null $connectionConfiguration Optional, specific database connection information.
      * @return ORMInfrastructure
      */
-    public static function createWithDependenciesFor(
-        $entityClassOrClasses,
-        ConnectionConfiguration $connectionConfiguration = null,
-        MappingDriver $mappingDriver = null,
-    ) {
+    public static function createWithDependenciesFor($entityClassOrClasses, ConnectionConfiguration $connectionConfiguration = null, MappingDriver $mappingDriver = null) {
         $entityClasses = static::normalizeEntityList($entityClassOrClasses);
         return new static(new EntityDependencyResolver($entityClasses, $mappingDriver), $connectionConfiguration, $mappingDriver);
     }
@@ -186,7 +182,7 @@ class ORMInfrastructure
      * @param ConnectionConfiguration|null $connectionConfiguration Optional, specific database connection information.
      * @return ORMInfrastructure
      */
-    public static function createOnlyFor($entityClassOrClasses, ConnectionConfiguration $connectionConfiguration = null, MappingDriver $mappingDriver = null,)
+    public static function createOnlyFor($entityClassOrClasses, ConnectionConfiguration $connectionConfiguration = null, MappingDriver $mappingDriver = null)
     {
         return new static(static::normalizeEntityList($entityClassOrClasses), $connectionConfiguration, $mappingDriver);
     }

--- a/src/ORMTestInfrastructure/ORMInfrastructure.php
+++ b/src/ORMTestInfrastructure/ORMInfrastructure.php
@@ -10,6 +10,7 @@
 namespace Webfactory\Doctrine\ORMTestInfrastructure;
 
 use Doctrine\Common\EventManager;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\ObjectRepository;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\DBAL\Logging\DebugStack;
@@ -168,10 +169,11 @@ class ORMInfrastructure
      */
     public static function createWithDependenciesFor(
         $entityClassOrClasses,
-        ConnectionConfiguration $connectionConfiguration = null
+        ConnectionConfiguration $connectionConfiguration = null,
+        MappingDriver $mappingDriver = null,
     ) {
         $entityClasses = static::normalizeEntityList($entityClassOrClasses);
-        return new static(new EntityDependencyResolver($entityClasses), $connectionConfiguration);
+        return new static(new EntityDependencyResolver($entityClasses, $mappingDriver), $connectionConfiguration, $mappingDriver);
     }
 
     /**
@@ -184,9 +186,9 @@ class ORMInfrastructure
      * @param ConnectionConfiguration|null $connectionConfiguration Optional, specific database connection information.
      * @return ORMInfrastructure
      */
-    public static function createOnlyFor($entityClassOrClasses, ConnectionConfiguration $connectionConfiguration = null)
+    public static function createOnlyFor($entityClassOrClasses, ConnectionConfiguration $connectionConfiguration = null, MappingDriver $mappingDriver = null,)
     {
-        return new static(static::normalizeEntityList($entityClassOrClasses), $connectionConfiguration);
+        return new static(static::normalizeEntityList($entityClassOrClasses), $connectionConfiguration, $mappingDriver);
     }
 
     /**
@@ -213,7 +215,7 @@ class ORMInfrastructure
      * @param ConnectionConfiguration|null $connectionConfiguration Optional, specific database connection information.
      * @deprecated Use one of the create*For() factory methods.
      */
-    public function __construct($entityClasses, ConnectionConfiguration $connectionConfiguration = null)
+    public function __construct($entityClasses, ConnectionConfiguration $connectionConfiguration = null, MappingDriver $mappingDriver = null)
     {
         // Register the annotation loader before the dependency discovery process starts (if required).
         // This ensures that the annotation loader is available for the entity resolver that reads the annotations.
@@ -229,7 +231,7 @@ class ORMInfrastructure
         $this->connectionConfiguration = $connectionConfiguration;
         $this->queryLogger             = new DebugStack();
         $this->namingStrategy          = new DefaultNamingStrategy();
-        $this->configFactory           = new ConfigurationFactory();
+        $this->configFactory           = new ConfigurationFactory($mappingDriver);
         $this->resolveTargetListener   = new ResolveTargetEntityListener();
 
         $this->eventSubscribers = [$this->resolveTargetListener];

--- a/tests/Config/ExistingConnectionConfigurationTest.php
+++ b/tests/Config/ExistingConnectionConfigurationTest.php
@@ -40,7 +40,7 @@ class ExistingConnectionConfigurationTest extends TestCase
     public function testWorksWithInfrastructure()
     {
         $infrastructure = ORMInfrastructure::createOnlyFor(
-            [TestEntity::class],
+            array(TestEntity::class),
             $this->connectionConfiguration
         );
 

--- a/tests/ORMTestInfrastructure/ConfigurationFactoryTest.php
+++ b/tests/ORMTestInfrastructure/ConfigurationFactoryTest.php
@@ -36,14 +36,6 @@ class ConfigurationFactoryTest extends TestCase
     }
 
     /**
-     * Cleans up the test environment.
-     */
-    protected function tearDown(): void
-    {
-        $this->factory = null;
-        parent::tearDown();
-    }
-    /**
      * Ensures that createFor() returns an ORM configuration object.
      */
     public function testCreateForReturnsConfiguration()

--- a/tests/ORMTestInfrastructure/Fixtures/EntityWithAttributes/TestEntity.php
+++ b/tests/ORMTestInfrastructure/Fixtures/EntityWithAttributes/TestEntity.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webfactory\Doctrine\Tests\ORMTestInfrastructure\Fixtures\EntityWithAttributes;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class TestEntity
+{
+    #[ORM\Id]
+    #[ORM\Column]
+    #[ORM\GeneratedValue]
+    public ?int $id = null;
+
+    #[ORM\Column(nullable: true)]
+    public ?string $name = null;
+}

--- a/tests/ORMTestInfrastructure/Fixtures/EntityWithAttributes/TestEntityWithDependency.php
+++ b/tests/ORMTestInfrastructure/Fixtures/EntityWithAttributes/TestEntityWithDependency.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Webfactory\Doctrine\Tests\ORMTestInfrastructure\Fixtures\EntityWithAttributes;
+
+use Doctrine\ORM\Mapping as ORM;
+use Webfactory\Doctrine\Tests\ORMTestInfrastructure\Fixtures\EntityWithAnnotation\ReferencedEntity;
+
+#[ORM\Entity]
+class TestEntityWithDependency
+{
+    #[ORM\Id]
+    #[ORM\Column]
+    #[ORM\GeneratedValue]
+    public ?int $id = null;
+
+    #[ORM\OneToOne(targetEntity: ReferencedEntity::class, cascade: ["all"])]
+    #[ORM\JoinColumn(nullable: false)]
+    public ?ReferencedEntity $dependency = null;
+
+    public function __construct()
+    {
+        $this->dependency = new ReferencedEntity();
+    }
+}


### PR DESCRIPTION
This PR makes it possible to transition to attribute-based or other types of Doctrine ORM mapping configuration by (optionally) passing the mapping driver into `ORMInfrastructure::create*()` methods.

Also, hybrid configurations (different types of mapping) can be used by leveraging the `MappingDriverChain` from doctrine/persistence.

