### PR TITLE
Replace `DebugStack` used for logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,19 +16,20 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
-        "doctrine/annotations": "^1.8|^2.0",
-        "doctrine/common": "^2.11|^3.0",
+        "php": ">= 8.0",
+        "doctrine/annotations": "^1.13|^2.0",
+        "doctrine/common": "^3.0",
         "doctrine/dbal": "^3.2",
-        "doctrine/event-manager": "^1.1|^2.0",
+        "doctrine/event-manager": "^1.2|^2.0",
         "doctrine/orm": "^2.14|^3.0",
-        "doctrine/persistence": "^2.0|^3.0",
-        "symfony/cache": "^5.0|^6.0|^7.0"
+        "doctrine/persistence": "^2.4|^3.0",
+        "psr/log": "^2.0|^3.0",
+        "symfony/cache": "^5.4|^6.0|^7.0"
     },
     "require-dev": {
         "doctrine/collections": "^1.6.8|^2.2.1",
         "phpunit/phpunit": "^9.6.19",
-        "symfony/error-handler": "^5.0|^6.0|^7.0",
+        "symfony/error-handler": "^5.4|^6.0|^7.0",
         "symfony/phpunit-bridge": ">= 7.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.4|^8.0",
         "doctrine/annotations": "^1.8|^2.0",
         "doctrine/common": "^2.11|^3.0",
-        "doctrine/dbal": "^2.12|^3.0",
+        "doctrine/dbal": "^3.2",
         "doctrine/event-manager": "^1.1|^2.0",
         "doctrine/orm": "^2.14|^3.0",
         "doctrine/persistence": "^2.0|^3.0",
@@ -28,7 +28,8 @@
     "require-dev": {
         "doctrine/collections": "^1.6.8|^2.2.1",
         "phpunit/phpunit": "^9.6.19",
-        "symfony/phpunit-bridge": "^6.0|^7.0"
+        "symfony/error-handler": "^5.0|^6.0|^7.0",
+        "symfony/phpunit-bridge": ">= 7.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd" bootstrap="vendor/autoload.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd" bootstrap="tests/bootstrap.php">
     <testsuites>
         <testsuite name="Library Test Suite">
             <directory>tests/</directory>

--- a/src/ORMTestInfrastructure/Query.php
+++ b/src/ORMTestInfrastructure/Query.php
@@ -11,10 +11,6 @@ namespace Webfactory\Doctrine\ORMTestInfrastructure;
 
 /**
  * Represents a query that has been executed.
- *
- * This class is designed to be populated by the data that is gathered by the DebugStack logger.
- *
- * @see \Doctrine\DBAL\Logging\DebugStack
  */
 class Query
 {
@@ -33,25 +29,16 @@ class Query
     protected $params = null;
 
     /**
-     * The execution time of the query in seconds.
-     *
-     * @var double
-     */
-    protected $executionTimeInSeconds = null;
-
-    /**
      * Currently not used:
      * - types
      *
      * @param string $sql - sql
      * @param mixed[] $params - params
-     * @param double $executionTimeInSeconds - executionMS
      */
-    public function __construct($sql, array $params, $executionTimeInSeconds)
+    public function __construct($sql, array $params)
     {
         $this->sql = $sql;
         $this->params = $params;
-        $this->executionTimeInSeconds = $executionTimeInSeconds;
     }
 
     /**
@@ -72,16 +59,6 @@ class Query
     public function getParams()
     {
         return $this->params;
-    }
-
-    /**
-     * Returns the execution time of the query in seconds.
-     *
-     * @return double
-     */
-    public function getExecutionTimeInSeconds()
-    {
-        return $this->executionTimeInSeconds;
     }
 
     /**

--- a/src/ORMTestInfrastructure/QueryLogger.php
+++ b/src/ORMTestInfrastructure/QueryLogger.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure;
+
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+
+class QueryLogger extends AbstractLogger
+{
+    public bool $enabled = true;
+    private array $queries = [];
+
+    public function log($level, \Stringable|string $message, array $context = []): void
+    {
+        if (!$this->enabled) {
+            return;
+        }
+
+        if (str_starts_with($message, 'Executing')) {
+            $this->queries[] = new Query($context['sql'], $context['params'] ?? []);
+        } else if ('Beginning transaction' === $message) {
+            $this->queries[] = new Query('"START TRANSACTION"', []);
+        } else if ('Committing transaction' === $message) {
+            $this->queries[] = new Query('"COMMIT"', []);
+        } else if ('Rolling back transaction' === $message) {
+            $this->queries[] = new Query('"ROLLBACK"', []);
+        }
+    }
+
+    public function getQueries()
+    {
+        return $this->queries;
+    }
+}

--- a/tests/ORMTestInfrastructure/QueryTest.php
+++ b/tests/ORMTestInfrastructure/QueryTest.php
@@ -32,8 +32,7 @@ class QueryTest extends TestCase
         parent::setUp();
         $this->query= new Query(
             'SELECT * FROM user WHERE id = ?',
-            array(42),
-            0.012
+            array(42)
         );
     }
 
@@ -60,14 +59,6 @@ class QueryTest extends TestCase
     public function testGetParamsReturnsCorrectValue()
     {
         $this->assertEquals(array(42), $this->query->getParams());
-    }
-
-    /**
-     * Ensures that the correct execution time is returned.
-     */
-    public function testGetExecutionTimeInSecondsReturnsCorrectValue()
-    {
-        $this->assertEquals(0.012, $this->query->getExecutionTimeInSeconds());
     }
 
     /**


### PR DESCRIPTION
`DebugStack` has been deprecated in DBAL 3.2 and will be removed in DBAL 4.
