### PR TITLE
Deprecate the `Query::getExecutionTimeInSeconds` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog for `webfactory/doctrine-orm-test-infrastructure`
+
+This changelog tracks deprecations and changes breaking backwards compatibility. For more details on particular releases, consult the [GitHub releases page](https://github.com/webfactory/doctrine-orm-test-infrastructure/releases).
+
+# Version 1.16
+
+- The `\Webfactory\Doctrine\ORMTestInfrastructure\Query::getExecutionTimeInSeconds()` method has been deprecated without replacement in https://github.com/webfactory/doctrine-orm-test-infrastructure/pull/52, to prepare for the removal of the `DebugStack` class in Doctrine DBAL 4.0.

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "doctrine/event-manager": "^1.1|^2.0",
         "doctrine/orm": "^2.14|^3.0",
         "doctrine/persistence": "^2.0|^3.0",
-        "symfony/cache": "^5.0|^6.0|^7.0"
+        "symfony/cache": "^5.0|^6.0|^7.0",
+        "symfony/deprecation-contracts": "^2.0|^3.0"
     },
     "require-dev": {
         "doctrine/collections": "^1.6.8|^2.2.1",

--- a/src/ORMTestInfrastructure/Query.php
+++ b/src/ORMTestInfrastructure/Query.php
@@ -81,6 +81,8 @@ class Query
      */
     public function getExecutionTimeInSeconds()
     {
+        trigger_deprecation('webfactory/doctrine-orm-test-infrastructure', '1.16', 'The %s method has been deprecated without a replacement and will be removed in 2.0');
+
         return $this->executionTimeInSeconds;
     }
 

--- a/tests/ORMTestInfrastructure/QueryTest.php
+++ b/tests/ORMTestInfrastructure/QueryTest.php
@@ -64,6 +64,8 @@ class QueryTest extends TestCase
 
     /**
      * Ensures that the correct execution time is returned.
+     *
+     * @group legacy
      */
     public function testGetExecutionTimeInSecondsReturnsCorrectValue()
     {


### PR DESCRIPTION
The `\Doctrine\DBAL\Logging\DebugStack` class is used by the `ORMInfrastructure` class to to collect the queries being executed. `DebugStack` has been deprecated in DBAL 3.2 (https://github.com/doctrine/dbal/pull/4967) and we will need to replace it with a logging middleware in the long run.

The logging middleware does not provide the query execution time, and it would be burdensome to implement this metric. Thus, for the time being, let's deprecate accessing the query execution time and remove this feature in the next major.