### PR TITLE
Replace `DebugStack` used for logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,13 @@
         "doctrine/event-manager": "^1.1|^2.0",
         "doctrine/orm": "^2.14|^3.0",
         "doctrine/persistence": "^2.0|^3.0",
+        "psr/log": "^2.0|^3.0",
         "symfony/cache": "^5.0|^6.0|^7.0"
     },
     "require-dev": {
         "doctrine/collections": "^1.6.8|^2.2.1",
         "phpunit/phpunit": "^9.6.19",
-        "symfony/error-handler": "^5.0|^6.0|^7.0",
+        "symfony/error-handler": "^5.4|^6.0|^7.0",
         "symfony/phpunit-bridge": ">= 7.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.0",
         "doctrine/common": "^2.11|^3.0",
-        "doctrine/dbal": "^2.12|^3.0",
+        "doctrine/dbal": "^3.2",
         "doctrine/deprecations": "^1.1",
         "doctrine/event-manager": "^1.1|^2.0",
         "doctrine/orm": "^2.14|^3.0",
@@ -28,7 +28,8 @@
     "require-dev": {
         "doctrine/collections": "^1.6.8|^2.2.1",
         "phpunit/phpunit": "^9.6.19",
-        "symfony/phpunit-bridge": "^6.0|^7.0"
+        "symfony/error-handler": "^5.0|^6.0|^7.0",
+        "symfony/phpunit-bridge": ">= 7.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd" bootstrap="vendor/autoload.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd" bootstrap="tests/bootstrap.php">
     <testsuites>
         <testsuite name="Library Test Suite">
             <directory>tests/</directory>

--- a/src/ORMTestInfrastructure/Query.php
+++ b/src/ORMTestInfrastructure/Query.php
@@ -11,10 +11,6 @@ namespace Webfactory\Doctrine\ORMTestInfrastructure;
 
 /**
  * Represents a query that has been executed.
- *
- * This class is designed to be populated by the data that is gathered by the DebugStack logger.
- *
- * @see \Doctrine\DBAL\Logging\DebugStack
  */
 class Query
 {

--- a/src/ORMTestInfrastructure/QueryLogger.php
+++ b/src/ORMTestInfrastructure/QueryLogger.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Webfactory\Doctrine\ORMTestInfrastructure;
+
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+
+class QueryLogger extends AbstractLogger
+{
+    public bool $enabled = true;
+    private array $queries = [];
+
+    public function log($level, \Stringable|string $message, array $context = []): void
+    {
+        if (!$this->enabled) {
+            return;
+        }
+
+        if (str_starts_with($message, 'Executing')) {
+            $this->queries[] = new Query($context['sql'], $context['params'] ?? []);
+        } else if ('Beginning transaction' === $message) {
+            $this->queries[] = new Query('"START TRANSACTION"', []);
+        } else if ('Committing transaction' === $message) {
+            $this->queries[] = new Query('"COMMIT"', []);
+        } else if ('Rolling back transaction' === $message) {
+            $this->queries[] = new Query('"ROLLBACK"', []);
+        }
+    }
+
+    public function getQueries()
+    {
+        return $this->queries;
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,8 @@
+<?php
+
+use Symfony\Component\ErrorHandler\Debug;
+use Symfony\Component\ErrorHandler\DebugClassLoader;
+
+require_once __DIR__.'/../vendor/autoload.php';
+
+DebugClassLoader::enable();


### PR DESCRIPTION
`DebugStack` has been deprecated in DBAL 3.2 and will be removed in DBAL 4.
