### PR TITLE
Replace removed DebugStack with LoggingMiddleware

### DIFF
--- a/src/Logging/Connection.php
+++ b/src/Logging/Connection.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Webfactory\Doctrine\Logging;
+
+use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
+use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement as StatementInterface;
+
+class Connection extends AbstractConnectionMiddleware
+{
+    public function __construct(ConnectionInterface $wrappedConnection, private readonly QueryCollection $queries)
+    {
+        parent::__construct($wrappedConnection);
+    }
+
+    public function prepare(string $sql): StatementInterface
+    {
+        return new Statement(parent::prepare($sql), $this->queries, $sql);
+    }
+
+    public function exec(string $sql): int
+    {
+        $start = microtime(true);
+        try {
+            return parent::exec($sql);
+        } finally {
+            $this->queries->addQuery(new Query($sql, [], microtime(true) - $start));
+        }
+    }
+
+    public function query(string $sql): Result
+    {
+        $start = microtime(true);
+        try {
+            return parent::query($sql);
+        } finally {
+            $this->queries->addQuery(new Query($sql, [], microtime(true) - $start));
+        }
+    }
+
+    public function beginTransaction(): void
+    {
+        $start = microtime(true);
+        try {
+            parent::beginTransaction();
+        } finally {
+            $this->queries->addQuery(new Query('"BEGIN TRANSACTION"', [], microtime(true) - $start));
+        }
+    }
+
+    public function commit(): void
+    {
+        $start = microtime(true);
+        try {
+            parent::commit();
+        } finally {
+            $this->queries->addQuery(new Query('"COMMIT"', [], microtime(true) - $start));
+        }
+    }
+
+    public function rollBack(): void
+    {
+        $start = microtime(true);
+        try {
+            parent::rollBack();
+        } finally {
+            $this->queries->addQuery(new Query('"ROLLBACK"', [], microtime(true) - $start));
+        }
+    }
+}

--- a/src/Logging/Driver.php
+++ b/src/Logging/Driver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Webfactory\Doctrine\Logging;
+
+use Doctrine\DBAL\Driver as DriverInterface;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+
+class Driver extends AbstractDriverMiddleware
+{
+    public function __construct(DriverInterface $wrappedDriver, private readonly QueryCollection $queries)
+    {
+        parent::__construct($wrappedDriver);
+    }
+
+    public function connect(array $params): DriverConnection
+    {
+        return new Connection(parent::connect($params), $this->queries);
+    }
+}

--- a/src/Logging/Middleware.php
+++ b/src/Logging/Middleware.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Webfactory\Doctrine\Logging;
+
+use Doctrine\DBAL\Driver as DriverInterface;
+
+class Middleware implements DriverInterface\Middleware
+{
+    private readonly QueryCollection $queries;
+
+    public function __construct()
+    {
+        $this->queries = new QueryCollection();
+    }
+
+    public function wrap(DriverInterface $driver): DriverInterface
+    {
+        return new Driver($driver, $this->queries);
+    }
+
+    /**
+     * @return Query[]
+     */
+    public function getQueries(): array
+    {
+        return $this->queries->queries;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->queries->enabled;
+    }
+
+    public function setEnabled(bool $enabled): void
+    {
+        $this->queries->enabled = $enabled;
+    }
+}

--- a/src/Logging/Query.php
+++ b/src/Logging/Query.php
@@ -7,58 +7,42 @@
  * file that was distributed with this source code.
  */
 
-namespace Webfactory\Doctrine\ORMTestInfrastructure;
+namespace Webfactory\Doctrine\Logging;
 
 /**
  * Represents a query that has been executed.
  */
 class Query
 {
-    /**
-     * The SQL query.
-     *
-     * @var string
-     */
-    protected $sql = null;
-
-    /**
-     * The assigned parameters.
-     *
-     * @var mixed[]
-     */
-    protected $params = null;
-
-    /**
-     * Currently not used:
-     * - types
-     *
-     * @param string $sql - sql
-     * @param mixed[] $params - params
-     */
-    public function __construct($sql, array $params)
-    {
-        $this->sql = $sql;
-        $this->params = $params;
+    public function __construct(
+        protected readonly string $sql,
+        protected readonly array $params,
+        protected readonly float $executionTimeInSeconds,
+    ) {
     }
 
     /**
      * Returns the SQL of the query.
-     *
-     * @return string
      */
-    public function getSql()
+    public function getSql(): string
     {
         return $this->sql;
     }
 
     /**
      * Returns a list of parameters that have been assigned to the statement.
-     *
-     * @return mixed[]
      */
-    public function getParams()
+    public function getParams(): array
     {
         return $this->params;
+    }
+
+    /**
+     * Returns the execution time of the query in seconds.
+     */
+    public function getExecutionTimeInSeconds(): float
+    {
+        return $this->executionTimeInSeconds;
     }
 
     /**

--- a/src/Logging/QueryCollection.php
+++ b/src/Logging/QueryCollection.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Webfactory\Doctrine\Logging;
+
+class QueryCollection
+{
+    /** @var array<Query> */
+    public array $queries = [];
+
+    public bool $enabled = true;
+
+    public function addQuery(Query $query): void
+    {
+        if ($this->enabled) {
+            $this->queries[] = $query;
+        }
+    }
+}

--- a/src/Logging/Statement.php
+++ b/src/Logging/Statement.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Webfactory\Doctrine\Logging;
+
+use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement as StatementInterface;
+use Doctrine\DBAL\ParameterType;
+
+class Statement extends AbstractStatementMiddleware
+{
+    private array $params = [];
+
+    public function __construct(
+        StatementInterface $wrappedStatement,
+        private readonly QueryCollection $queries,
+        private readonly string $sql
+    ) {
+        parent::__construct($wrappedStatement);
+    }
+
+    public function bindValue($param, $value, $type = ParameterType::STRING): void
+    {
+        $this->params[$param] = $value;
+
+        parent::bindValue($param, $value, $type);
+    }
+
+    public function execute($params = []): Result
+    {
+        $start = microtime(true);
+        try {
+            return parent::execute();
+        } finally {
+            $this->queries->addQuery(new Query($this->sql, $this->params, microtime(true) - $start));
+        }
+    }
+}


### PR DESCRIPTION
With the removal of the DebugStack in #57, the `getExecutionTimeInSeconds` function had to be removed.

Using a dedicated middleware allow the feature to be restored.