### PR TITLE
Allow doctrine/persistence ^4.0 to be used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     },
     "require-dev": {
         "doctrine/collections": "^1.6.8|^2.2.1",
-        "phpunit/phpunit": "^10.5.58"
+        "phpunit/phpunit": "^10.5.58",
+        "symfony/var-exporter": "^6.4|^7.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/dbal": "^3.2",
         "doctrine/event-manager": "^1.1|^2.0",
         "doctrine/orm": "^2.20|^3.0",
-        "doctrine/persistence": "^2.5|^3.0",
+        "doctrine/persistence": "^2.5|^3.0|^4.0",
         "psr/log": "^2.0|^3.0",
         "symfony/cache": "^6.4|^7.0"
     },


### PR DESCRIPTION
From what can be seen in their CHANGELOG, this should not affect us.